### PR TITLE
Add the function about get all card info about selected card series and show on card-series page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fancyapps/ui": "^5.0.36",
         "@fortawesome/fontawesome-free": "^6.7.0",
+        "axios": "^1.7.7",
         "pinia": "^2.2.6",
         "swiper": "^11.1.15",
         "vue": "^3.5.12",
@@ -1823,7 +1824,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
@@ -1862,6 +1862,17 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2096,7 +2107,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2292,7 +2302,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2523,6 +2532,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -2544,7 +2573,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
       "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3206,7 +3234,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3216,7 +3243,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -3789,6 +3815,12 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@fancyapps/ui": "^5.0.36",
     "@fortawesome/fontawesome-free": "^6.7.0",
+    "axios": "^1.7.7",
     "pinia": "^2.2.6",
     "swiper": "^11.1.15",
     "vue": "^3.5.12",

--- a/src/assets/css/card-series/main-content.css
+++ b/src/assets/css/card-series/main-content.css
@@ -451,8 +451,12 @@ input[type="checkbox"] {
   font-size: 20px; 
 }
 
+.active {
+  background-color: #06B6D4;
+}
+
 .change-sheet {
-  background-color: #06b6d4;
+  /* background-color: #06b6d4; */
   position: relative;
 }
 

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,2 +1,3 @@
 /* @import "./base.css"; */
 @import "@fortawesome/fontawesome-free/css/all.css";
+

--- a/src/stores/card-series.js
+++ b/src/stores/card-series.js
@@ -1,0 +1,107 @@
+import { ref, computed } from "vue";
+import { defineStore } from "pinia";
+import axios from "axios";
+
+export const useCardSeriesStore = defineStore("card-series", () => {
+  const currentSeriesData = ref("");
+  const serieslastReleaseTime = ref("");
+  const seriesCode = ref("");
+  const seriesCardList = ref([]);
+
+  // リコリス測試用資料
+  const seriesTestData = ref("");
+
+  // 獲取指定系列資訊;
+  const getCurrentSeries = async (seriesId = 1559042) => {
+    try {
+      const res = await axios.get("/api/series");
+      // console.log(res.data);
+      res.data.find((series) => {
+        if (series.id === seriesId) {
+          currentSeriesData.value = series;
+        }
+      });
+      //   console.log(currentSeriesData.value.sellAt);
+      if (currentSeriesData.value.sellAt == undefined) {
+        getCardSeriesCompleteInfo();
+      } else {
+        serieslastReleaseTime.value =
+          currentSeriesData.value.sellAt[
+            currentSeriesData.value.sellAt.length - 1
+          ];
+        seriesCode.value = currentSeriesData.value.code.join(",");
+      }
+    } catch (err) {
+      console.log(err, "系列獲取失敗");
+    }
+  };
+
+  // 獲取指定系列所有卡牌資訊;
+  const getSeriesCards = async (seriesId = 1559042) => {
+    try {
+      const res = await axios.get(`/api/card/${seriesId}`);
+      //   console.log(res.data);
+      res.data.forEach((card) => {
+        if (card.type === "キャラ") {
+          card.typeTranslate = "角色";
+        } else if (card.type === "イベント") {
+          card.typeTranslate = "事件";
+        } else if (card.type === "クライマックス") {
+          card.typeTranslate = "名場";
+        }
+      });
+      seriesCardList.value = res.data;
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  // 獲取指定系列的完整卡牌資訊，把getCurrentSeries、getSeriesCards放在一起調用
+  const getCardSeriesCompleteInfo = async (seriesId) => {
+      await getCurrentSeries(seriesId);
+      await getSeriesCards(seriesId);
+  };
+
+  // 拿取測試用資料
+  const getTestSeriesData = async () => {
+    try {
+      const res = await axios.get("/api/series");
+      //   console.log(res.data);
+      res.data.find((series) => {
+        if (series.id === 1559042) {
+          seriesTestData.value = series;
+        }
+      });
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  const saveLastViewSeries = () => {
+    if (currentSeriesData.value || seriesCardList.value) {
+      localStorage.setItem("lastViewSeriesId", currentSeriesData.value.id);
+    }
+  };
+
+  const getLastViewSeries = async () => {
+    if (currentSeriesData.value == "" || seriesCardList.value == "") {
+      const lastViewSeriesId = localStorage.getItem("lastViewSeriesId");
+      if (lastViewSeriesId) {
+        // console.log("開始重新獲取");
+        await getCardSeriesCompleteInfo(lastViewSeriesId);
+      }
+    }
+  };
+
+  return {
+    currentSeriesData,
+    serieslastReleaseTime,
+    seriesCode,
+    seriesCardList,
+    seriesTestData,
+    getTestSeriesData,
+    getCardSeriesCompleteInfo,
+    saveLastViewSeries,
+    getLastViewSeries,
+  };
+});

--- a/src/views/Card List by Series.vue
+++ b/src/views/Card List by Series.vue
@@ -241,9 +241,9 @@
                             <span class="font-size75rem color-a1">一共有{{}}結果</span>
                         </h2>
                         <section class="grid-card">
-                            <a href="#" class="url transition-colors">
+                            <RouterLink to="/card-series" class="url transition-colors" @click="handleSeries(this.seriesTestData.id)">
                                 <div>
-                                    <img src="https://jasonxddd.me:9000/series-cover/osk_176×176.jpg" alt="">
+                                    <img :src="seriesTestData.cover" alt="">
                                 </div>
                                 <div class="card-text">
                                     <div class="flex">
@@ -253,12 +253,12 @@
                                             <path d="M18 7.5a3 3 0 0 1 3 3V18a3 3 0 0 1-3 3h-7.5a3 3 0 0 1-3-3v-7.5a3 3 0 0 1 3-3H18Z">
                                             </path>
                                         </svg>
-                                        <p class="color-a1">OSK</p>
+                                        <p class="color-a1">{{ 123 }}</p>
                                     </div>
-                                    <p class="font-size20 color-white padding-bottom" >【我推的孩子】</p>
-                                    <p class="color-a1">2023-12-08</p>
+                                    <p class="font-size20 color-white padding-bottom" >跳轉頁面測試用</p>
+                                    <p class="color-a1">{{ 123 }}</p>
                                 </div>
-                            </a>
+                            </RouterLink>
                             <a href="#" class="url transition-colors">
                                 <div>
                                     <img src="https://jasonxddd.me:9000/series-cover/osk_176×176.jpg" alt="">
@@ -558,8 +558,28 @@
 </template>
 
 <script>
+import { useCardSeriesStore } from "@/stores/card-series";
+import { storeToRefs } from "pinia";
+
 export default {
-  methods: {
+    data(){
+        const cardSeriesStore = useCardSeriesStore();
+        const { seriesTestData } = storeToRefs(cardSeriesStore);
+        
+        return{
+            seriesTestData,
+            getTestSeriesData: cardSeriesStore.getTestSeriesData,
+            getCardSeriesCompleteInfo: cardSeriesStore.getCardSeriesCompleteInfo,
+            saveLastViewSeries: cardSeriesStore.saveLastViewSeries,
+        }
+    },
+    methods: {
+    async handleSeries(seriesId){
+        await this.getCardSeriesCompleteInfo(seriesId);
+        // console.log("成功獲取資料，執行跳轉至CardSeriesPage");
+        this.saveLastViewSeries();
+        // 點擊系列後獲取該系列ID，作為參數調用card-series store裡獲取指定系列資料的function拿到資料，然後順便跳轉到CardSeriesPage，並將現在瀏覽的系列ID存在localstorage
+    },
     toggleArrow(event) {
       const button = event.currentTarget;
       if (!button) return; // 防止按鈕為 null 的情況
@@ -594,8 +614,11 @@ export default {
     },
     clearInput() {
       document.getElementById("searchInput").value = ""; // 清空輸入框的文字
+      },
     },
-  },
+    async created() {
+        await this.getTestSeriesData();        
+    },
 };
 </script>
 <style scoped>

--- a/src/views/CardSeries.vue
+++ b/src/views/CardSeries.vue
@@ -1,5 +1,12 @@
 <script setup>
-  import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, onBeforeMount } from "vue";
+import { useCardSeriesStore } from "@/stores/card-series";
+import { storeToRefs } from "pinia";
+
+const cardSeriesStore = useCardSeriesStore();
+
+const { currentSeriesData, serieslastReleaseTime, seriesCode, seriesCardList } =
+  storeToRefs(cardSeriesStore);
   
   const currentSidebar = ref('');
   const sidebarFilterWidth = ref(490);
@@ -65,9 +72,10 @@
     }
   }
   
-  
-  onMounted(() => {
+  // Lifecycle hooks
+  onMounted(async() => {
     window.addEventListener('resize', updateScreenSize);
+    await cardSeriesStore.getLastViewSeries();
   });
   
   onBeforeUnmount(() => {
@@ -510,14 +518,14 @@
         <section class="info-container">
           <img src="https://jasonxddd.me:9000/series-cover/rikoriko.jpg">
           <div flex-col class="inner-info-container">
-            <span><i class="fa-regular fa-clone"></i> LRC</span>
-            <h1>リコリス・リコイル</h1>
+            <span><i class="fa-regular fa-clone"></i> {{ seriesCode }}</span>
+            <h1>{{ currentSeriesData.name }}</h1>
             <div>
               <div>
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentcolor" width="20" height="20" class="icon-scale size-5 md:size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46"></path></svg><span>最新發布2024-11-15</span>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentcolor" width="20" height="20" class="icon-scale size-5 md:size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46"></path></svg><span>最新發布{{ serieslastReleaseTime }}</span>
               </div>
               <div>
-                <i class="fa-regular fa-clone"></i><span>總數208張</span>
+                <i class="fa-regular fa-clone"></i><span>總數{{ seriesCardList.length }}張</span>
               </div>
               <div>
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="16" height="16" aria-hidden="true" data-slot="icon" class="icon-scale size-5 md:size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z"></path></svg><span>篩選出208張</span>
@@ -540,72 +548,12 @@
           </div>
           <div v-if="view === 'card-sheet'" class="card-sheet">
             <div class="row">
-              <div class="col-Sheet">
+              <div class="col-Sheet" v-for="(card, index) in seriesCardList" :key="card.id">
                 <div class="card-image">
                   <img src="https://jasonxddd.me:7001/imgproxy/4nZhC0JVu4aRvo6ml6VI37hURt9V19vRRN5Wo54yrqU/g:no/el:1/bG9jYWw6Ly8vL0xSQ19XMTA1XzAwMS5wbmc.png">
                   <div>
-                    <p>LRC/W105-001</p>
-                    <h3>酔いどれ？店員 ミズキ</h3>
-                  </div>
-                  <button data-v-69cfbdbc="" class="group-hover:bg-zinc-800 group-hover:shadow group-hover:shadow-zinc-800/50 flex-none rounded-full p-1 shadow-xl will-change-[background,shadow] transition-all"><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" width="24" height="24" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
-                </div>
-              </div>
-              <div class="col-Sheet">
-                <div class="card-image">
-                  <img src="https://jasonxddd.me:7001/imgproxy/4nZhC0JVu4aRvo6ml6VI37hURt9V19vRRN5Wo54yrqU/g:no/el:1/bG9jYWw6Ly8vL0xSQ19XMTA1XzAwMS5wbmc.png">
-                  <div>
-                    <p>LRC/W105-001</p>
-                    <h3>酔いどれ？店員 ミズキ</h3>
-                  </div>
-                  <button data-v-69cfbdbc="" class="group-hover:bg-zinc-800 group-hover:shadow group-hover:shadow-zinc-800/50 flex-none rounded-full p-1 shadow-xl will-change-[background,shadow] transition-all"><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" width="24" height="24" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
-                </div>
-              </div>
-              <div class="col-Sheet">
-                <div class="card-image">
-                  <img src="https://jasonxddd.me:7001/imgproxy/4nZhC0JVu4aRvo6ml6VI37hURt9V19vRRN5Wo54yrqU/g:no/el:1/bG9jYWw6Ly8vL0xSQ19XMTA1XzAwMS5wbmc.png">
-                  <div>
-                    <p>LRC/W105-001</p>
-                    <h3>酔いどれ？店員 ミズキ</h3>
-                  </div>
-                  <button data-v-69cfbdbc="" class="group-hover:bg-zinc-800 group-hover:shadow group-hover:shadow-zinc-800/50 flex-none rounded-full p-1 shadow-xl will-change-[background,shadow] transition-all"><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" width="24" height="24" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
-                </div>
-              </div>
-              <div class="col-Sheet">
-                <div class="card-image">
-                  <img src="https://jasonxddd.me:7001/imgproxy/4nZhC0JVu4aRvo6ml6VI37hURt9V19vRRN5Wo54yrqU/g:no/el:1/bG9jYWw6Ly8vL0xSQ19XMTA1XzAwMS5wbmc.png">
-                  <div>
-                    <p>LRC/W105-001</p>
-                    <h3>酔いどれ？店員 ミズキ</h3>
-                  </div>
-                  <button data-v-69cfbdbc="" class="group-hover:bg-zinc-800 group-hover:shadow group-hover:shadow-zinc-800/50 flex-none rounded-full p-1 shadow-xl will-change-[background,shadow] transition-all"><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" width="24" height="24" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
-                </div>
-              </div>
-              <div class="col-Sheet">
-                <div class="card-image">
-                  <img src="https://jasonxddd.me:7001/imgproxy/4nZhC0JVu4aRvo6ml6VI37hURt9V19vRRN5Wo54yrqU/g:no/el:1/bG9jYWw6Ly8vL0xSQ19XMTA1XzAwMS5wbmc.png">
-                  <div>
-                    <p>LRC/W105-001</p>
-                    <h3>酔いどれ？店員 ミズキ</h3>
-                  </div>
-                  <button data-v-69cfbdbc="" class="group-hover:bg-zinc-800 group-hover:shadow group-hover:shadow-zinc-800/50 flex-none rounded-full p-1 shadow-xl will-change-[background,shadow] transition-all"><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" width="24" height="24" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
-                </div>
-              </div>
-              <div class="col-Sheet">
-                <div class="card-image">
-                  <img src="https://jasonxddd.me:7001/imgproxy/4nZhC0JVu4aRvo6ml6VI37hURt9V19vRRN5Wo54yrqU/g:no/el:1/bG9jYWw6Ly8vL0xSQ19XMTA1XzAwMS5wbmc.png">
-                  <div>
-                    <p>LRC/W105-001</p>
-                    <h3>酔いどれ？店員 ミズキ</h3>
-                  </div>
-                  <button data-v-69cfbdbc="" class="group-hover:bg-zinc-800 group-hover:shadow group-hover:shadow-zinc-800/50 flex-none rounded-full p-1 shadow-xl will-change-[background,shadow] transition-all"><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" width="24" height="24" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
-                </div>
-              </div>
-              <div class="col-Sheet">
-                <div class="card-image">
-                  <img src="https://jasonxddd.me:7001/imgproxy/4nZhC0JVu4aRvo6ml6VI37hURt9V19vRRN5Wo54yrqU/g:no/el:1/bG9jYWw6Ly8vL0xSQ19XMTA1XzAwMS5wbmc.png">
-                  <div>
-                    <p>LRC/W105-001</p>
-                    <h3>酔いどれ？店員 ミズキ</h3>
+                    <p>{{ card.id }}</p>
+                    <h3>{{ card.title }}</h3>
                   </div>
                   <button data-v-69cfbdbc="" class="group-hover:bg-zinc-800 group-hover:shadow group-hover:shadow-zinc-800/50 flex-none rounded-full p-1 shadow-xl will-change-[background,shadow] transition-all"><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" width="24" height="24" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
                 </div>
@@ -615,139 +563,24 @@
     
           <div v-if="view === 'card-info'" class="card-info">
             <div class="row">
-              <div class="col-Info">
+              <div class="col-Info" v-for="(card, index) in seriesCardList" :key="card.id">
                 <div class="card-info-image">
                   <img src="https://jasonxddd.me:7001/imgproxy/4nZhC0JVu4aRvo6ml6VI37hURt9V19vRRN5Wo54yrqU/g:no/el:1/bG9jYWw6Ly8vL0xSQ19XMTA1XzAwMS5wbmc.png">
                   <div class="card-inner-info">
                     <div class="card-inner-info-header">
-                      <p>LRC/W105-001</p>
-                      <p>RR</p>
+                      <p>{{ card.id }}</p>
+                      <p>{{ card.rare }}</p>
                     </div>
-                    <h3>酔いどれ？店員 ミズキ</h3>
+                    <h3>{{ card.title }}</h3>
                     <div class="details">
-                      <div><span>類型</span>角色</div>
-                      <div><span>魂傷</span>1</div>
-                      <div><span>等級</span>0</div>
-                      <div><span>攻擊</span>500</div>
-                      <div><span>費用</span>0</div>
+                      <div><span>類型</span>{{ card.typeTranslate }}</div>
+                      <div><span>魂傷</span>{{ card.soul }}</div>
+                      <div><span>等級</span>{{ card.level }}</div>
+                      <div><span>攻擊</span>{{ card.attack }}</div>
+                      <div><span>費用</span>{{ card.cost }}</div>
                     </div>
                     <div class="price-download">
-                      <p>$420</p>
-                      <button><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="col-Info">
-                <div class="card-info-image">
-                  <img src="https://jasonxddd.me:7001/imgproxy/4nZhC0JVu4aRvo6ml6VI37hURt9V19vRRN5Wo54yrqU/g:no/el:1/bG9jYWw6Ly8vL0xSQ19XMTA1XzAwMS5wbmc.png">
-                  <div class="card-inner-info">
-                    <div class="card-inner-info-header">
-                      <p>LRC/W105-001</p>
-                      <p>RR</p>
-                    </div>
-                    <h3>酔いどれ？店員 ミズキ</h3>
-                    <div class="details">
-                      <div><span>類型</span>角色</div>
-                      <div><span>魂傷</span>1</div>
-                      <div><span>等級</span>0</div>
-                      <div><span>攻擊</span>500</div>
-                      <div><span>費用</span>0</div>
-                    </div>
-                    <div class="price-download">
-                      <p>$420</p>
-                      <button><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="col-Info">
-                <div class="card-info-image">
-                  <img src="https://jasonxddd.me:7001/imgproxy/4nZhC0JVu4aRvo6ml6VI37hURt9V19vRRN5Wo54yrqU/g:no/el:1/bG9jYWw6Ly8vL0xSQ19XMTA1XzAwMS5wbmc.png">
-                  <div class="card-inner-info">
-                    <div class="card-inner-info-header">
-                      <p>LRC/W105-001</p>
-                      <p>RR</p>
-                    </div>
-                    <h3>酔いどれ？店員 ミズキ</h3>
-                    <div class="details">
-                      <div><span>類型</span>角色</div>
-                      <div><span>魂傷</span>1</div>
-                      <div><span>等級</span>0</div>
-                      <div><span>攻擊</span>500</div>
-                      <div><span>費用</span>0</div>
-                    </div>
-                    <div class="price-download">
-                      <p>$420</p>
-                      <button><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="col-Info">
-                <div class="card-info-image">
-                  <img src="https://jasonxddd.me:7001/imgproxy/4nZhC0JVu4aRvo6ml6VI37hURt9V19vRRN5Wo54yrqU/g:no/el:1/bG9jYWw6Ly8vL0xSQ19XMTA1XzAwMS5wbmc.png">
-                  <div class="card-inner-info">
-                    <div class="card-inner-info-header">
-                      <p>LRC/W105-001</p>
-                      <p>RR</p>
-                    </div>
-                    <h3>酔いどれ？店員 ミズキ</h3>
-                    <div class="details">
-                      <div><span>類型</span>角色</div>
-                      <div><span>魂傷</span>1</div>
-                      <div><span>等級</span>0</div>
-                      <div><span>攻擊</span>500</div>
-                      <div><span>費用</span>0</div>
-                    </div>
-                    <div class="price-download">
-                      <p>$420</p>
-                      <button><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="col-Info">
-                <div class="card-info-image">
-                  <img src="https://jasonxddd.me:7001/imgproxy/4nZhC0JVu4aRvo6ml6VI37hURt9V19vRRN5Wo54yrqU/g:no/el:1/bG9jYWw6Ly8vL0xSQ19XMTA1XzAwMS5wbmc.png">
-                  <div class="card-inner-info">
-                    <div class="card-inner-info-header">
-                      <p>LRC/W105-001</p>
-                      <p>RR</p>
-                    </div>
-                    <h3>酔いどれ？店員 ミズキ</h3>
-                    <div class="details">
-                      <div><span>類型</span>角色</div>
-                      <div><span>魂傷</span>1</div>
-                      <div><span>等級</span>0</div>
-                      <div><span>攻擊</span>500</div>
-                      <div><span>費用</span>0</div>
-                    </div>
-                    <div class="price-download">
-                      <p>$420</p>
-                      <button><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="col-Info">
-                <div class="card-info-image">
-                  <img src="https://jasonxddd.me:7001/imgproxy/4nZhC0JVu4aRvo6ml6VI37hURt9V19vRRN5Wo54yrqU/g:no/el:1/bG9jYWw6Ly8vL0xSQ19XMTA1XzAwMS5wbmc.png">
-                  <div class="card-inner-info">
-                    <div class="card-inner-info-header">
-                      <p>LRC/W105-001</p>
-                      <p>RR</p>
-                    </div>
-                    <h3>酔いどれ？店員 ミズキ</h3>
-                    <div class="details">
-                      <div><span>類型</span>角色</div>
-                      <div><span>魂傷</span>1</div>
-                      <div><span>等級</span>0</div>
-                      <div><span>攻擊</span>500</div>
-                      <div><span>費用</span>0</div>
-                    </div>
-                    <div class="price-download">
-                      <p>$420</p>
+                      <p>${{ card.price.number }}</p>
                       <button><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
                     </div>
                   </div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,4 +15,12 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'https://bottleneko.app',
+        changeOrigin: true,
+      },
+    }, // 處理api跨域請求，設定代理伺服器
+  }, 
 })


### PR DESCRIPTION
安裝axios
![image](https://github.com/user-attachments/assets/96397a57-fec7-440b-b706-d2f31ee14c74)
新增功能至card-series相關的store
![image](https://github.com/user-attachments/assets/7995fdee-dd8b-463d-914a-f6b6d3b42b5d)
打api有遇到好像是跨域問題無法順利取得資料，在新增代理伺服器設定後可以拿的到，實際原因不確定是什麼
![image](https://github.com/user-attachments/assets/50e44709-64c4-4290-b0a5-5b3bb6e1cbf4)
CardList頁面新增跳轉至CardSeries頁面的測試用功能，之後可以移除
![image](https://github.com/user-attachments/assets/62a7f476-0387-4468-9ec9-4b523fe0a98a)
![image](https://github.com/user-attachments/assets/184f223a-8ffe-4f2c-9ac2-3e47a3bc1141)
![image](https://github.com/user-attachments/assets/91cb245b-eb07-4f20-8b9c-6cc9b259e95a)
CardSeries頁面引入獲取的卡片資訊並顯示
![image](https://github.com/user-attachments/assets/2c6399ba-4938-49e8-adb4-4a3b8d9c1f53)
![image](https://github.com/user-attachments/assets/97e8879b-5178-4c0f-8e23-3a2546a79bde)

