### PR TITLE
add card-info feature, fix some card-series page's style and change card series api request method from frontend to backend

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,16 @@
 <script setup>
 import { RouterLink, RouterView } from "vue-router";
+import CardInfo from "@/views/CardInfo.vue";
+import { storeToRefs } from "pinia";
+import { useCardInfoStore } from "@/stores/card-info";
+
+const cardInfoStore = useCardInfoStore();
+const { cardInfoDisplay } = storeToRefs(cardInfoStore);
 </script>
 
 <template>
   <RouterView />
+  <!-- <CardInfo v-if="cardInfoDisplay" /> -->
 </template>
 
 <style scoped>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { RouterLink, RouterView } from "vue-router";
-import CardInfo from "@/views/CardInfo.vue";
+// import CardInfo from "@/views/CardInfo.vue";
 import { storeToRefs } from "pinia";
 import { useCardInfoStore } from "@/stores/card-info";
 

--- a/src/assets/css/card-series/main-content.css
+++ b/src/assets/css/card-series/main-content.css
@@ -314,7 +314,22 @@ input[type="checkbox"] {
   z-index: 2;
 }
 
-.toggle-deck::before {
+/* 修改成定位方式 */
+.toggle-deck-content{
+  position: relative;
+}
+
+.toggle-deck-content p {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 22px;
+  font-weight: 700;
+  color: rgb(17, 94, 89);
+}
+
+/* .toggle-deck::before {
   content: "0";
   font-weight: 700;
   font-size: 1.25rem;
@@ -328,7 +343,7 @@ input[type="checkbox"] {
   top: 8px; 
   left: 20px; 
   z-index: 2; 
-}
+} */
 
 .toggle-deck:hover {
   background-color:#14B8A6;
@@ -346,10 +361,10 @@ input[type="checkbox"] {
   height: 40px;
 }
 
-.toggle-deck:hover::before {
+/* .toggle-deck:hover::before {
   transform: translateX(8px);
   transition-duration: 0.3s;
-}
+} */
 
 .info-container {
   margin-top: 70px;
@@ -657,9 +672,29 @@ input[type="checkbox"] {
 
 .details span{
   margin-right: 5px;
-  background-color: #CA8A04;
+  /* background-color: #CA8A04; */
   border-radius: 7px;
   padding: 2px;
+}
+
+.bg-red {
+  background-color: #ef4444;
+}
+
+.bg-blue {
+  background-color: #3b82f6;
+}
+
+.bg-green {
+  background-color: #22c55e;
+}
+
+.bg-yellow {
+  background-color: #eab308;
+}
+
+.bg-purple {
+  background-color: #a855f7;
 }
 
 .price-download {

--- a/src/assets/css/card-series/sidebar-deck.css
+++ b/src/assets/css/card-series/sidebar-deck.css
@@ -480,14 +480,18 @@
   display: flex;
   flex-direction: column;
   justify-content: space-evenly;
-  gap: 12px;
+  gap: 10px;
 }
 
 .deck-save-covercard-section-content-card h3 {
-  max-width: 100%;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  /* text-overflow: ellipsis; */
+  /* white-space: nowrap; */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  line-height: 24px;
+  
 }
 
 

--- a/src/assets/css/card-series/sidebar-deck.css
+++ b/src/assets/css/card-series/sidebar-deck.css
@@ -1,3 +1,8 @@
+::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
 .sidebar-deck {
   width: 490px;
   display: flex;
@@ -463,9 +468,10 @@
 }
 
 .deck-save-covercard-section-content-card img{
-  max-width: 64px;
+  min-width: 64px;
   max-height: 64px;
   object-fit: cover;
+  object-position: top;
   border-radius: 8px;
 }
 

--- a/src/assets/css/login-homepage/Login Homepage.css
+++ b/src/assets/css/login-homepage/Login Homepage.css
@@ -151,6 +151,7 @@ nav {
   top: 0px;
   left: 270px;
   z-index: 50;
+  box-sizing: border-box;
 }
 
 .search-bar-logo {

--- a/src/stores/card-info.js
+++ b/src/stores/card-info.js
@@ -1,0 +1,20 @@
+import { ref, computed } from "vue";
+import { defineStore } from "pinia";
+import router from '../router/index'
+
+export const useCardInfoStore = defineStore("card-info", () => {
+    const cardInfoDisplay = ref(false);
+    const cardInfo = ref(null); 
+    const getCardInfoAndShow = (card) => {
+        cardInfo.value = card;
+        console.log(cardInfo.value);
+        console.log("成功傳入卡片資訊");
+        cardInfoDisplay.value = true;
+    }
+
+    return {
+        cardInfoDisplay,
+        cardInfo,
+        getCardInfoAndShow,
+    }
+})

--- a/src/stores/deck-make.js
+++ b/src/stores/deck-make.js
@@ -1,9 +1,12 @@
 import { ref, computed } from "vue";
 import { defineStore } from "pinia";
 import axios from "axios";
-import Swal from 'sweetalert2'
+import { useCardInfoStore } from "./card-info";
 
 export const useDeckMakeStore = defineStore("deck-make", () => {
+  const cardInfoStore = useCardInfoStore();
+  const getCardInfoAndShow = cardInfoStore.getCardInfoAndShow;
+
   const selectedCards = ref([]);
   const editType = ref("CHECK_INFO");
   const showCardPrice = ref(false);
@@ -36,7 +39,7 @@ export const useDeckMakeStore = defineStore("deck-make", () => {
 
     selectedCards.value.splice(cardIndex, 1);
     saveLastDeckEdit();
-    // switchSortMode();
+    switchSortMode();
   };
 
   // 清空製作牌組內的卡牌和重置最後編輯狀態
@@ -99,6 +102,7 @@ export const useDeckMakeStore = defineStore("deck-make", () => {
         "卡片索引值:" + cardIndex,
         "牌組索引值:" + deckIndex
       );
+      getCardInfoAndShow(card)
     } else if (editType.value === "ADD_CARD") {
       addCard(card);
       switchSortMode();
@@ -190,7 +194,6 @@ export const useDeckMakeStore = defineStore("deck-make", () => {
         });
         sortedDeck.value.push(cardArr);
       });
-
     } else if (sortStatus.value === "RARE") {
       const typeArr = [];
       // console.log(selectedCards.value);
@@ -225,7 +228,9 @@ export const useDeckMakeStore = defineStore("deck-make", () => {
         if (typeArr.length <= 0) {
           typeArr.push(card.productName);
         }
-        const ishave = typeArr.find((productName) => productName === card.productName);
+        const ishave = typeArr.find(
+          (productName) => productName === card.productName
+        );
         if (ishave === undefined) {
           typeArr.push(card.productName);
           // console.log(card.productName);
@@ -251,16 +256,25 @@ export const useDeckMakeStore = defineStore("deck-make", () => {
   const handleSwitchBtnClick = (switchType) => {
     sortStatus.value = switchType;
     switchSortMode();
-  }
+  };
 
   // 傳送給後端存入資料庫
-  const sendDeckToDatabase = async(deckData) => {
-    const userToken = localStorage.getItem('token');
-    const res = await axios.post('http://localhost:3000/api/add-deck', 
-      { userToken, deckData });
+  const sendDeckToDatabase = async (deckData) => {
+    const userToken = localStorage.getItem("token");
+    const res = await axios.post("http://localhost:3000/api/add-deck", {
+      userToken,
+      deckData,
+    });
     console.log(res.data);
-    return res
-  }
+    return res;
+  };
+
+  // 獲取卡片在牌組中的數量
+  const countCards = (card) => {
+    return selectedCards.value.filter((selectedCard) => {
+      return selectedCard.id === card.id;
+    }).length;
+  };
 
   return {
     addCard,
@@ -279,6 +293,7 @@ export const useDeckMakeStore = defineStore("deck-make", () => {
     sortStatus,
     switchSortMode,
     handleSwitchBtnClick,
-    sendDeckToDatabase
+    sendDeckToDatabase,
+    countCards
   };
 });

--- a/src/views/Card List by Series.vue
+++ b/src/views/Card List by Series.vue
@@ -241,7 +241,7 @@
                             <span class="font-size75rem color-a1">一共有{{}}結果</span>
                         </h2>
                         <section class="grid-card">
-                            <RouterLink to="/card-series" class="url transition-colors" @click="handleSeries(this.seriesTestData.id)">
+                            <RouterLink to="/card-series" class="url transition-colors" @click="handleSeries(2976541)">
                                 <div>
                                     <img :src="seriesTestData.cover" alt="">
                                 </div>
@@ -253,10 +253,10 @@
                                             <path d="M18 7.5a3 3 0 0 1 3 3V18a3 3 0 0 1-3 3h-7.5a3 3 0 0 1-3-3v-7.5a3 3 0 0 1 3-3H18Z">
                                             </path>
                                         </svg>
-                                        <p class="color-a1">{{ 123 }}</p>
+                                        <p class="color-a1">{{ seriesTestData.code }}</p>
                                     </div>
                                     <p class="font-size20 color-white padding-bottom" >跳轉頁面測試用</p>
-                                    <p class="color-a1">{{ 123 }}</p>
+                                    <p class="color-a1">{{ seriesTestData.sellAt }}</p>
                                 </div>
                             </RouterLink>
                             <a href="#" class="url transition-colors">
@@ -565,19 +565,18 @@ export default {
     data(){
         const cardSeriesStore = useCardSeriesStore();
         const { seriesTestData } = storeToRefs(cardSeriesStore);
-        
         return{
-            seriesTestData,
-            getTestSeriesData: cardSeriesStore.getTestSeriesData,
-            getCardSeriesCompleteInfo: cardSeriesStore.getCardSeriesCompleteInfo,
+            getSeriesCards: cardSeriesStore.getSeriesCards,
             saveLastViewSeries: cardSeriesStore.saveLastViewSeries,
+            seriesTestData,
+            getTestSeries: cardSeriesStore.getTestSeries
         }
     },
     methods: {
     async handleSeries(seriesId){
-        await this.getCardSeriesCompleteInfo(seriesId);
+        await this.getSeriesCards(seriesId);
         // console.log("成功獲取資料，執行跳轉至CardSeriesPage");
-        this.saveLastViewSeries();
+        this.saveLastViewSeries(seriesId);
         // 點擊系列後獲取該系列ID，作為參數調用card-series store裡獲取指定系列資料的function拿到資料，然後順便跳轉到CardSeriesPage，並將現在瀏覽的系列ID存在localstorage
     },
     toggleArrow(event) {
@@ -616,8 +615,8 @@ export default {
       document.getElementById("searchInput").value = ""; // 清空輸入框的文字
       },
     },
-    async created() {
-        await this.getTestSeriesData();        
+    async mounted() {
+        await this.getTestSeries(1559042);
     },
 };
 </script>

--- a/src/views/Card List by Series.vue
+++ b/src/views/Card List by Series.vue
@@ -241,7 +241,7 @@
                             <span class="font-size75rem color-a1">一共有{{}}結果</span>
                         </h2>
                         <section class="grid-card">
-                            <RouterLink to="/card-series" class="url transition-colors" @click="handleSeries(2976541)">
+                            <RouterLink to="/card-series" class="url transition-colors" @click="handleSeries(1559042)">
                                 <div>
                                     <img :src="seriesTestData.cover" alt="">
                                 </div>

--- a/src/views/CardInfo.vue
+++ b/src/views/CardInfo.vue
@@ -1,3 +1,110 @@
+<script setup>
+import { ref, onMounted, computed, watch } from 'vue'
+import { storeToRefs } from "pinia";
+import { useCardInfoStore } from "@/stores/card-info";
+import { useDeckMakeStore } from "@/stores/deck-make";
+
+const cardInfoStore = useCardInfoStore();
+const { cardInfo, cardInfoDisplay } = storeToRefs(cardInfoStore);
+
+const deckMakeStore = useDeckMakeStore();
+console.log(cardInfo.value);
+const { selectedCards } = storeToRefs(deckMakeStore);
+
+const addCard = deckMakeStore.addCard
+const removeCard = deckMakeStore.removeCard
+const countCards = deckMakeStore.countCards
+
+const cardInfoDesc = computed(() => {
+    return cardInfo.value.effect
+    .replace(/<img[^>]*>/g, '')
+    .replace(/【(.*?)】/g, '<mark class="mark-4">【$1】</mark>')
+})
+console.log(cardInfoDesc.value);
+
+// 卡片在牌組中的數量
+const cardCount = ref(0)
+// 監聽卡片在牌組中的數量並更新
+watch(selectedCards.value, () => {
+    cardCount.value = countCards(cardInfo.value)
+    // console.log(cardCount.value);
+})
+
+const iconTextColor = computed(() => {
+    if(cardInfo.value.color == 'red'){
+        return `text-red-700`
+    }else if(cardInfo.value.color == 'blue'){
+        return `text-blue-700`
+    }else if(cardInfo.value.color == 'green'){
+        return `text-green-700`
+    }else if(cardInfo.value.color == 'yellow'){
+        return `text-yellow-700`
+    }else if(cardInfo.value.color == 'purple'){
+        return `text-purple-700`
+    }
+})
+
+const iconBgColor = computed(() => {
+    if(cardInfo.value.color == 'red'){
+        return `bg-red-200`
+    }else if(cardInfo.value.color == 'blue'){
+        return `bg-blue-200`
+    }else if(cardInfo.value.color == 'green'){
+        return `bg-green-200`
+    }else if(cardInfo.value.color == 'yellow'){
+        return `bg-yellow-200`
+    }else if(cardInfo.value.color == 'purple'){
+        return `bg-purple-200`
+    }
+})
+
+const iconShadowColor = computed(() => {
+    if(cardInfo.value.color == 'red'){
+        return `shadow-red-200/50`
+    }else if(cardInfo.value.color == 'blue'){
+        return `shadow-blue-200/50`
+    }else if(cardInfo.value.color == 'green'){
+        return `shadow-green-200/50`
+    }else if(cardInfo.value.color == 'yellow'){
+        return `shadow-yellow-200/50`
+    }else if(cardInfo.value.color == 'purple'){
+        return `shadow-purple-200/50`
+    }
+})
+
+const textColor = computed(() => {
+    if(cardInfo.value.color == 'red'){
+        return `text-red-100`
+    }else if(cardInfo.value.color == 'blue'){
+        return `text-blue-100`
+    }else if(cardInfo.value.color == 'green'){
+        return `text-green-100`
+    }else if(cardInfo.value.color == 'yellow'){
+        return `text-yellow-100`
+    }else if(cardInfo.value.color == 'purple'){
+        return `text-purple-100`
+    }
+})
+
+const bgColor = computed(() => {
+    if(cardInfo.value.color == 'red'){
+        return `bg-red-700/50`
+    }else if(cardInfo.value.color == 'blue'){
+        return `bg-blue-700/50`
+    }else if(cardInfo.value.color == 'green'){
+        return `bg-green-700/50`
+    }else if(cardInfo.value.color == 'yellow'){
+        return `bg-yellow-700/50`
+    }else if(cardInfo.value.color == 'purple'){
+        return `bg-purple-700/50`
+    }
+})
+
+onMounted(() => {
+    cardCount.value = countCards(cardInfo.value)
+})
+
+</script>
 <template>
     <section class="fixed top-0 left-0 w-screen h-screen z-[100] grid overflow-y-auto overflow-x-hidden md:overflow-hidden backdrop-blur place-content-center">
         <div class="flex items-center gap-4 w-[80vw] 2xl:w-[70vw] h-[80vh]">
@@ -8,7 +115,7 @@
             </button>
             <div class="card flex-none rounded-2xl relative p-0 w-4/12 overflow-hidden shadow-[0_4px_8px_rgba(0,0,0,0.1)]">
                 <div class="absolute top-0 left-0 w-full h-full glossy z-2 mix-blend-lighten"></div>
-                <img class="flex-none object-cover w-full min-w-0 shadow-lg select-none rounded-card aspect-card default-transition bg-image" src="https://jasonxddd.me:7001/imgproxy/uTz5Qc1RtmVq-UACufPxVQk-G0eFfKvKWXNGEImcyHc/rt:fill/w:0/h:0/g:no/el:1/f:png/bG9jYWw6Ly8vL0hPTF9XMTA0XzEyM1NTUC5wbmc.png" alt="" size="sm:100vw md:50vw lg:600px">
+                <img class="flex-none object-cover w-full min-w-0 shadow-lg select-none rounded-card aspect-card default-transition bg-image" :src="cardInfo.cover" alt="" size="sm:100vw md:50vw lg:600px">
                 <button class="absolute bottom-0 p-4 text-white rounded-full md-arrow left-2 bg-black/50 disabled:bg-black/30 disabled:text-white/20 hover:bg-cyan-500">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="stroke-2 size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"></path>
                     </svg>
@@ -22,13 +129,13 @@
                 <div class="sticky top-0 z-10 px-4 pt-4 shadow-xl rounded-xl bg-zinc-800">
                     <div class="flex items-center justify-between w-full gap-2">
                         <div class="flex items-center counter gap-x-1">
-                            <button class="text-white btn btn-sm bg-zinc-700 hover:bg-green-400">
+                            <button class="text-white btn btn-sm bg-zinc-700 hover:bg-green-400" @click="addCard(cardInfo)" >
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="stroke-2 size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"></path></svg>
                             </button>
                             <div class="text-white btn btn-sm bg-zinc-700">
-                                <span class="text-center stroke-2 size-6">0</span>
+                                <span class="stroke-2 size-6 flex items-center justify-center">{{ cardCount }}</span>
                             </div>
-                            <button class="text-white btn btn-sm bg-zinc-700 hover:bg-red-400">
+                            <button class="text-white btn btn-sm bg-zinc-700 hover:bg-red-400" @click="removeCard(cardInfo)" >
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="stroke-2 size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14"></path></svg>
                             </button>
                         </div>
@@ -38,7 +145,7 @@
                                     <path stroke-linecap="round" stroke-linejoin="round" d="m10.5 21 5.25-11.25L21 21m-9-3h7.5M3 5.621a48.474 48.474 0 0 1 6-.371m0 0c1.12 0 2.233.038 3.334.114M9 5.25V3m3.334 2.364C11.176 10.658 7.69 15.08 3 17.502m9.334-12.138c.896.061 1.785.147 2.666.257m-4.589 8.495a18.023 18.023 0 0 1-3.827-5.802"></path>
                                 </svg>
                             </button>
-                            <button class="flex-none text-white btn btn-sm bg-black/70 hover:bg-white hover:text-black">
+                            <button class="flex-none text-white btn btn-sm bg-black/70 hover:bg-white hover:text-black" @click="cardInfoDisplay = false" >
                                 <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"></path>
                                 </svg>
@@ -47,39 +154,41 @@
                     </div>
                     <div class="flex items-center mt-4 gap-x-2">
                         <div class="flex flex-col items-center justify-center w-16 gap-2">
-                            <div class="p-2 text-blue-700 bg-blue-200 rounded-full shadow-lg shadow-blue-200/50">
-                                <svg  class="size-8" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+                            <div :class="['p-2', iconTextColor, iconBgColor, 'rounded-full', 'shadow-lg', iconShadowColor]">
+                                <svg v-if="cardInfo.typeTranslate === '角色' " class="size-8" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"></path>
                                 </svg>
+                                <svg v-else-if="cardInfo.typeTranslate === '名場' " xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-8"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"></path></svg>
+                                <svg v-else-if="cardInfo.typeTranslate === '事件' " xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-8"><path stroke-linecap="round" stroke-linejoin="round" d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z"></path></svg>
                             </div>
-                            <p class="w-full text-xs text-center text-white truncate">角色</p>
+                            <p class="w-full text-xs text-center text-white truncate">{{ cardInfo.typeTranslate }}</p>
                         </div>
                         <div>
-                            <p class="font-mono text-xs text-zinc-300">HOL/W104-123SSP</p>
-                            <h3 class="text-2xl font-bold text-white">STELLAR into the GALAXY 星街すいせい</h3>
-                            <p class="text-zinc-300">#ホロライブプロダクション Vol.2</p>
+                            <p class="font-mono text-xs text-zinc-300">{{ cardInfo.id }}</p>
+                            <h3 class="text-2xl font-bold text-white">{{ cardInfo.title }}</h3>
+                            <p class="text-zinc-300">{{ cardInfo.productName }}</p>
                         </div>
                     </div>
                     <div class="flex flex-wrap items-center gap-2 mt-4">
                         <div class="flex items-center">
-                            <span class="relative px-1 text-blue-100 rounded z-1 whitespace-nowrap bg-blue-700/50">等級</span>
-                            <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">3</span>
+                            <span :class="['relative', 'px-1', textColor, 'rounded', 'z-1', 'whitespace-nowrap', bgColor]">等級</span>
+                            <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">{{ cardInfo.level }}</span>
                         </div>
                         <div class="flex items-center">
-                            <span class="relative px-1 text-blue-100 rounded z-1 whitespace-nowrap bg-blue-700/50">費用</span>
-                            <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">2</span>
+                            <span :class="['relative', 'px-1', textColor, 'rounded', 'z-1', 'whitespace-nowrap', bgColor]">費用</span>
+                            <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">{{ cardInfo.cost }}</span>
                         </div>
                         <div class="flex items-center">
-                            <span class="relative px-1 text-blue-100 rounded z-1 whitespace-nowrap bg-blue-700/50">魂傷</span>
-                            <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">2</span>
+                            <span :class="['relative', 'px-1', textColor, 'rounded', 'z-1', 'whitespace-nowrap', bgColor]">魂傷</span>
+                            <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">{{ cardInfo.soul }}</span>
                         </div>
                         <div class="flex items-center">
-                            <span class="relative px-1 text-blue-100 rounded z-1 whitespace-nowrap bg-blue-700/50">攻擊</span>
-                            <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">10000</span>
+                            <span :class="['relative', 'px-1', textColor, 'rounded', 'z-1', 'whitespace-nowrap', bgColor]">攻擊</span>
+                            <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">{{cardInfo.attack  }}</span>
                         </div>
                         <div class="flex items-center">
-                            <span class="relative px-1 text-blue-100 rounded z-1 whitespace-nowrap bg-blue-700/50">稀有度</span>
-                            <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">SSP</span>
+                            <span :class="['relative', 'px-1', textColor, 'rounded', 'z-1', 'whitespace-nowrap', bgColor]">稀有度</span>
+                            <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">{{ cardInfo.rare }}</span>
                         </div>
                     </div>
                     <div class="flex items-center justify-around gap-2 mt-6 overflow-auto">
@@ -91,44 +200,49 @@
                             </div>
                             <p class="hidden px-0 md:block md:pl-1 md:pr-2 whitespace-nowrap">資訊</p>
                         </button>
-                        <button class="flex items-center rounded-full group default-transition bg-zinc-700 text-zinc-100 hover:bg-cyan-700 hover:text-cyan-100">
-                            <div class="btn btn-sm default-transition bg-zinc-600 group-hover:bg-cyan-600">
-                                <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"></path>
-                                </svg>
-                            </div>
-                            <p class="hidden px-0 md:block md:pl-1 md:pr-2 whitespace-nowrap">價格</p>
-                        </button>
-                        <button class="flex items-center rounded-full group default-transition bg-zinc-700 text-zinc-100 hover:bg-cyan-700 hover:text-cyan-100">
-                            <div class="btn btn-sm default-transition bg-zinc-600 group-hover:bg-cyan-600">
-                                <svg class="w-6 h-6" cxmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"></path>
-                                </svg>
-                            </div>
-                            <p class="hidden px-0 md:block md:pl-1 md:pr-2 whitespace-nowrap">QA</p>
-                        </button>
-                        <button class="flex items-center rounded-full group default-transition bg-zinc-700 text-zinc-100 hover:bg-cyan-700 hover:text-cyan-100">
-                            <div class="btn btn-sm default-transition bg-zinc-600 group-hover:bg-cyan-600">
-                                <svg class="w-6 h-6" cxmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z"></path>
-                                </svg>
-                            </div>
-                            <p class="hidden px-0 md:block md:pl-1 md:pr-2 whitespace-nowrap">留言</p>
-                        </button>
+                        <a href="#information">
+                            <button class="flex items-center rounded-full group default-transition bg-zinc-700 text-zinc-100 hover:bg-cyan-700 hover:text-cyan-100">
+                                <div class="btn btn-sm default-transition bg-zinc-600 group-hover:bg-cyan-600">
+                                    <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"></path>
+                                    </svg>
+                                </div>
+                                <p class="hidden px-0 md:block md:pl-1 md:pr-2 whitespace-nowrap">價格</p>
+                            </button>
+                        </a>
+                        <a href="#pricearea">
+                            <button class="flex items-center rounded-full group default-transition bg-zinc-700 text-zinc-100 hover:bg-cyan-700 hover:text-cyan-100">
+                                <div class="btn btn-sm default-transition bg-zinc-600 group-hover:bg-cyan-600">
+                                    <svg class="w-6 h-6" cxmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"></path>
+                                    </svg>
+                                </div>
+                                <p class="hidden px-0 md:block md:pl-1 md:pr-2 whitespace-nowrap">QA</p>
+                            </button>
+                        </a>
+                        <a href="#qaarea">
+                            <button class="flex items-center rounded-full group default-transition bg-zinc-700 text-zinc-100 hover:bg-cyan-700 hover:text-cyan-100">
+                                <div class="btn btn-sm default-transition bg-zinc-600 group-hover:bg-cyan-600">
+                                    <svg class="w-6 h-6" cxmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z"></path>
+                                    </svg>
+                                </div>
+                                <p class="hidden px-0 md:block md:pl-1 md:pr-2 whitespace-nowrap">留言</p>
+                            </button>
+                        </a>
                     </div>
                     <hr class="my-2 -mx-4 border-zinc-700">
                 </div>
-                <div class="flex flex-col gap-4 p-4">
+                <div id="information"  class="flex flex-col gap-4 p-4">
                     <h4 class="flex items-center gap-1 text-cyan-500">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-6">
                             <path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"></path>
                         </svg>
                         <span class="text-lg font-bold leading-none">資訊</span>
                     </h4>
-                    <p class="text-sm leading-relaxed text-white whitespace-pre-line"><mark class="mark-4">【自】</mark> このカードが手札から舞台に置かれた時、あなたは自分のクロックの上から1枚を、控え室に置いてよい。
-                        <mark class="mark-4">【自】</mark><mark class="mark-4">【CXコンボ】</mark> あなたのアタックフェイズの始めに、クライマックス置場に<mark class="mark-3">「COMET」</mark>があり、前列にこのカードがいるなら、次の2つの効果のうちあなたが選んだ1つを行う。<mark class="mark-1">『あなたは相手のキャラすべてを、思い出にしてよい。そうしたら、あなたはそれらのキャラを舞台の別々の枠に置く。』</mark><mark class="mark-1">『そのターン中、このカードは次の能力を得る。『<mark class="mark-4">【自】</mark><mark class="mark-2">［<mark class="mark-6">(1)</mark> 手札を1枚控え室に置く］</mark> このカードがアタックした時、あなたはコストを払ってよい。そうしたら、相手に2ダメージを与える。』</mark>（ダメージキャンセルは発生する）
+                    <p class="text-sm leading-relaxed text-white whitespace-pre-line" v-html="cardInfoDesc" >
                     </p>
-                    <hr class="my-2 -mx-4 border-zinc-700">
+                    <hr id="pricearea" class="my-2 -mx-4 border-zinc-700">
                     <h4 class="flex items-center gap-1 text-cyan-500">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-6">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"></path>
@@ -140,11 +254,11 @@
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="m9 7.5 3 4.5m0 0 3-4.5M12 12v5.25M15 12H9m6 3H9m12-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"></path>
                             </svg>
-                            <h3 class="font-mono text-6xl font-bold">448000</h3>
+                            <h3 class="font-mono text-6xl font-bold">{{ cardInfo.price.number }}</h3>
                         </div>
                         <p class="mt-4 text-sm text-zinc-500 dark:text-zinc-300">於 2024-11-07 遊々亭價格更新</p>
                     </div>
-                    <hr class="my-2 -mx-4 border-zinc-700">
+                    <hr id="qaarea" class="my-2 -mx-4 border-zinc-700">
                     <h4 class="flex items-center gap-1 text-cyan-500">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-6">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"></path>
@@ -210,6 +324,8 @@
 </template>
 
 <style scoped>
+@import '@/assets/base.css';
+
 *, :after, :before {
     border: 0 solid #e5e7eb;
     box-sizing: border-box;


### PR DESCRIPTION
新增card-info的store
- 
![image](https://github.com/user-attachments/assets/dfd30615-fcfd-4ede-97f2-c97be3b15ee7)
![image](https://github.com/user-attachments/assets/4cd9a549-6964-422b-941f-a59274348fab)

CardInfo.vue新增一些功能、補上tailwind引入
*QA不確定怎麼判斷要抓取哪些、留言部分因為還沒有樣式所以暫時沒做功能
*翻譯功能因為是整個網站一起更改的可能之後再跟其他頁面一起做
-
![image](https://github.com/user-attachments/assets/0174f749-fb3c-4c21-b841-38799099b147)
![image](https://github.com/user-attachments/assets/394bdc74-99ba-4440-81e8-f16fd4b68d5e)
![image](https://github.com/user-attachments/assets/7be34112-9a51-4111-979e-bdc30f5c8369)

將card-info改成用component方式引入測試新增的功能，因為有設定path會衝突所以測試完後先註解掉了
-
![image](https://github.com/user-attachments/assets/b10cf5f0-51d6-4494-9b2a-63c2942320df)

修改一些card-series的樣式、顯示目前牌組內數量、根據卡片顏色更改顏色
-
![image](https://github.com/user-attachments/assets/3f7f17ae-06a4-4b1a-a17f-8124b915fd89)
![image](https://github.com/user-attachments/assets/846c85e4-9ec3-44a6-baf8-9d79facbde7f)

將獲取系列卡片的api請求改為後端讀取存放於後端的json檔案後回傳，重新調整card-series、deck-make store裡的功能
-
![image](https://github.com/user-attachments/assets/a20efc11-7546-4893-bb76-ea1f8f1832e1)
