### PR TITLE
add card-info's switch-card feature

### DIFF
--- a/src/stores/card-info.js
+++ b/src/stores/card-info.js
@@ -1,20 +1,84 @@
 import { ref, computed } from "vue";
-import { defineStore } from "pinia";
-import router from '../router/index'
+import { defineStore, storeToRefs } from "pinia";
+import router from "../router/index";
+import { useDeckMakeStore } from "./deck-make";
 
 export const useCardInfoStore = defineStore("card-info", () => {
-    const cardInfoDisplay = ref(false);
-    const cardInfo = ref(null); 
-    const getCardInfoAndShow = (card) => {
-        cardInfo.value = card;
-        console.log(cardInfo.value);
-        console.log("成功傳入卡片資訊");
-        cardInfoDisplay.value = true;
-    }
+  const deckMakeStore = useDeckMakeStore();
+  const { selectedCards } = storeToRefs(deckMakeStore);
 
-    return {
-        cardInfoDisplay,
-        cardInfo,
-        getCardInfoAndShow,
+  const cardInfoDisplay = ref(false);
+  const cardInfo = ref(null);
+  const cardIndex = ref(null);
+
+  const leftDisabled = ref(null);
+  const rightDisabled = ref(null);
+
+  const getCardInfoAndShow = (card) => {
+    cardInfo.value = card;
+    // console.log(cardInfo.value);
+    // console.log("成功傳入卡片資訊");
+    console.log("成功調用getCardInfoAndShow");
+  
+    cardInfoDisplay.value = true;
+    getCardInfoIndex();
+  };
+
+  // 獲取目前CardInfo顯示卡片在牌組製作陣列中的位置
+  const getCardInfoIndex = () => {
+    cardIndex.value = selectedCards.value.findIndex((card) => {
+      return card.id === cardInfo.value.id;
+    });
+    
+    console.log(cardIndex.value);
+    if(cardIndex.value == -1){
+      setTimeout(() => {
+        leftDisabled.value = true;
+        console.log("左按鈕被觸發:" + leftDisabled.value);
+        rightDisabled.value = true;
+        console.log("右按鈕被觸發:" + rightDisabled.value);
+      },0)
     }
-})
+    
+    if(cardIndex.value == 0){
+      leftDisabled.value = true;
+      rightDisabled.value = false;
+    }else if(cardIndex.value === selectedCards.value.length - 1){
+      leftDisabled.value = false;
+      rightDisabled.value = true;
+    }else if(cardIndex.value != 0 && cardIndex.value != selectedCards.value.length - 1){
+      leftDisabled.value = false;
+      rightDisabled.value = false;
+    }
+    
+  };
+
+  // 切換顯示的卡片
+  const changeCardInfoCard = (direction) => {
+    getCardInfoIndex();
+    if (cardIndex.value != -1) {
+        console.log(cardIndex.value + "不等於" + -1);
+      if (direction == "left") {
+        rightDisabled.value = false;
+        if (cardIndex.value > 0) {
+          cardInfo.value = selectedCards.value[cardIndex.value - 1];
+        }
+      } else if (direction == "right") {
+        leftDisabled.value = false;
+        if (cardIndex.value < selectedCards.value.length - 1) {
+          cardInfo.value = selectedCards.value[cardIndex.value + 1];
+        }
+      }
+    }
+  };
+
+  return {
+    cardInfoDisplay,
+    cardInfo,
+    getCardInfoAndShow,
+    getCardInfoIndex,
+    changeCardInfoCard,
+    leftDisabled,
+    rightDisabled,
+  };
+});

--- a/src/stores/card-series.js
+++ b/src/stores/card-series.js
@@ -1,4 +1,4 @@
-import { ref, computed } from "vue";
+import { ref, computed, reactive } from "vue";
 import { defineStore } from "pinia";
 import axios from "axios";
 
@@ -6,6 +6,7 @@ export const useCardSeriesStore = defineStore("card-series", () => {
   
   const serieslastReleaseTime = ref("");
   const seriesCode = ref("");
+  const seriesInfo = ref("");
   const seriesCardList = ref([]);
 
   // リコリス測試用資料
@@ -39,7 +40,14 @@ export const useCardSeriesStore = defineStore("card-series", () => {
   // 獲取指定系列所有卡牌資訊;
   const getSeriesCards = async (seriesId) => {
     try {
-      console.log("獲取真正的系列卡牌");
+      const seriesRes = await axios.get(`http://localhost:3000/api/serise`);
+      const selectedSeries = seriesRes.data.find((series) => {
+        return series.id == seriesId;
+      })
+      console.log(selectedSeries);
+      seriesInfo.value = selectedSeries;
+      console.log(seriesInfo.value);
+      
       const res = await axios.get(`http://localhost:3000/api/serise/${seriesId}`);
         // console.log(res.data);
       res.data.forEach((card) => {
@@ -85,6 +93,7 @@ export const useCardSeriesStore = defineStore("card-series", () => {
     saveLastViewSeries,
     getLastViewSeries,
     seriesTestData,
-    getTestSeries
+    getTestSeries,
+    seriesInfo,
   };
 });

--- a/src/stores/deck-make.js
+++ b/src/stores/deck-make.js
@@ -1,11 +1,11 @@
 import { ref, computed } from "vue";
 import { defineStore } from "pinia";
 import axios from "axios";
-import { useCardInfoStore } from "./card-info";
+import { useCardInfoStore } from "@/stores/card-info";
 
 export const useDeckMakeStore = defineStore("deck-make", () => {
   const cardInfoStore = useCardInfoStore();
-  const getCardInfoAndShow = cardInfoStore.getCardInfoAndShow;
+  // const getCardInfoAndShow = cardInfoStore.getCardInfoAndShow;
 
   const selectedCards = ref([]);
   const editType = ref("CHECK_INFO");
@@ -97,12 +97,12 @@ export const useDeckMakeStore = defineStore("deck-make", () => {
   const checkTypeAndRunFunction = (card, cardIndex, deckIndex) => {
     if (editType.value === "CHECK_INFO") {
       console.log("查看卡片資訊");
-      console.log(
-        "卡片資訊:" + card,
-        "卡片索引值:" + cardIndex,
-        "牌組索引值:" + deckIndex
-      );
-      getCardInfoAndShow(card)
+      // console.log(
+        //   "卡片資訊:" + card.name,
+        //   "卡片索引值:" + cardIndex,
+      //   "牌組索引值:" + deckIndex
+      // );
+      cardInfoStore.getCardInfoAndShow(card);
     } else if (editType.value === "ADD_CARD") {
       addCard(card);
       switchSortMode();
@@ -260,10 +260,9 @@ export const useDeckMakeStore = defineStore("deck-make", () => {
 
   // 傳送給後端存入資料庫
   const sendDeckToDatabase = async (deckData) => {
-    
     console.log(deckData);
     const userToken = localStorage.getItem("token");
-    
+
     const res = await axios.post("http://localhost:3000/api/add-deck", {
       userToken,
       deckData,
@@ -297,6 +296,6 @@ export const useDeckMakeStore = defineStore("deck-make", () => {
     switchSortMode,
     handleSwitchBtnClick,
     sendDeckToDatabase,
-    countCards
+    countCards,
   };
 });

--- a/src/views/Card List by Series.vue
+++ b/src/views/Card List by Series.vue
@@ -110,7 +110,7 @@
                         </div>
                         <h2 class="font-size30 color-white h2-padding">之前查看系列</h2>
                         <section class="show-card">
-                            <a v-for="card in cardSeries" :key="card.id" href="#" class="url transition-colors">
+                            <a v-for="card in cardSeries" :key="card.id" href="#" class="url transition-colors" @click.prevent="handleSeries(card.id)" >
                                     <div>
                                         <img :src ="card.cover || '/src/img/cover.png'" alt="">
                                     </div>
@@ -151,7 +151,7 @@
                                     <p class="color-a1">{{ seriesTestData.sellAt }}</p>
                                 </div>
                             </RouterLink> -->
-                            <a v-for="card in cardSeries" :key="card.id" href="#" class="url transition-colors">
+                            <a v-for="card in cardSeries" :key="card.id" href="#" class="url transition-colors" @click.prevent="handleSeries(card.id)" >
                                     <div>
                                         <img :src ="card.cover || '/src/img/cover.png'" alt="">
                                     </div>
@@ -363,24 +363,16 @@ import { ref, onMounted } from 'vue';
 import { useCardSeriesStore } from "@/stores/card-series";
 import { storeToRefs } from "pinia";
 import axios from "axios";
+import { useRouter } from 'vue-router'
+
+const router = useRouter(); 
 
 //     export default {
 //     data(){
-//         const cardSeriesStore = useCardSeriesStore();
-//         const { seriesTestData } = storeToRefs(cardSeriesStore);
-//         return{
-//             getSeriesCards: cardSeriesStore.getSeriesCards,
-//             saveLastViewSeries: cardSeriesStore.saveLastViewSeries,
-//             seriesTestData,
-//             getTestSeries: cardSeriesStore.getTestSeries
-//         }
+//         
 //     },
 //     methods: {
-//     async handleSeries(seriesId){
-//         await this.getSeriesCards(seriesId);
-//         // console.log("成功獲取資料，執行跳轉至CardSeriesPage");
-//         this.saveLastViewSeries(seriesId);
-//         // 點擊系列後獲取該系列ID，作為參數調用card-series store裡獲取指定系列資料的function拿到資料，然後順便跳轉到CardSeriesPage，並將現在瀏覽的系列ID存在localstorage
+//     
 //     },
 //     toggleArrow(event) {
 //       const button = event.currentTarget;
@@ -436,6 +428,17 @@ const fetchCardseries = async () => {
         error.value = '獲取系列卡表資料失敗' + err.message
     }
 };
+
+const cardSeriesStore = useCardSeriesStore();
+
+const getSeriesCards = cardSeriesStore.getSeriesCards;
+const saveLastViewSeries = cardSeriesStore.saveLastViewSeries;
+    
+const handleSeries = async(seriesId) => {
+    router.push('/card-series');
+    await getSeriesCards(seriesId);
+    saveLastViewSeries(seriesId);
+}
 
 onMounted(() => {
     fetchCardseries();

--- a/src/views/CardInfo.vue
+++ b/src/views/CardInfo.vue
@@ -1,26 +1,29 @@
 <script setup>
-import { ref, onMounted, computed, watch } from 'vue'
+import { ref, onMounted, computed, watch, onBeforeMount } from 'vue'
 import { storeToRefs } from "pinia";
 import { useCardInfoStore } from "@/stores/card-info";
 import { useDeckMakeStore } from "@/stores/deck-make";
 
 const cardInfoStore = useCardInfoStore();
-const { cardInfo, cardInfoDisplay } = storeToRefs(cardInfoStore);
+const { cardInfo, cardInfoDisplay, leftDisabled, rightDisabled } = storeToRefs(cardInfoStore);
+const getCardInfoIndex = cardInfoStore.getCardInfoIndex
+const changeCardInfoCard = cardInfoStore.changeCardInfoCard
 
 const deckMakeStore = useDeckMakeStore();
-console.log(cardInfo.value);
+// console.log(cardInfo.value);
 const { selectedCards } = storeToRefs(deckMakeStore);
 
 const addCard = deckMakeStore.addCard
 const removeCard = deckMakeStore.removeCard
 const countCards = deckMakeStore.countCards
 
-const cardInfoDesc = computed(() => {
-    return cardInfo.value.effect
-    .replace(/<img[^>]*>/g, '')
-    .replace(/【(.*?)】/g, '<mark class="mark-4">【$1】</mark>')
-})
-console.log(cardInfoDesc.value);
+// 暫時註解掉，以便修改功能
+// const cardInfoDesc = computed(() => {
+//     return cardInfo.value.effect
+//     .replace(/<img[^>]*>/g, '')
+//     .replace(/【(.*?)】/g, '<mark class="mark-4">【$1】</mark>')
+// })
+// console.log(cardInfoDesc.value);
 
 // 卡片在牌組中的數量
 const cardCount = ref(0)
@@ -30,74 +33,80 @@ watch(selectedCards.value, () => {
     // console.log(cardCount.value);
 })
 
-const iconTextColor = computed(() => {
-    if(cardInfo.value.color == 'red'){
-        return `text-red-700`
-    }else if(cardInfo.value.color == 'blue'){
-        return `text-blue-700`
-    }else if(cardInfo.value.color == 'green'){
-        return `text-green-700`
-    }else if(cardInfo.value.color == 'yellow'){
-        return `text-yellow-700`
-    }else if(cardInfo.value.color == 'purple'){
-        return `text-purple-700`
-    }
-})
+// 動態更改顏色暫時註解掉，以便修改功能
+// const iconTextColor = computed(() => {
+//     if(cardInfo.value.color == 'red'){
+//         return `text-red-700`
+//     }else if(cardInfo.value.color == 'blue'){
+//         return `text-blue-700`
+//     }else if(cardInfo.value.color == 'green'){
+//         return `text-green-700`
+//     }else if(cardInfo.value.color == 'yellow'){
+//         return `text-yellow-700`
+//     }else if(cardInfo.value.color == 'purple'){
+//         return `text-purple-700`
+//     }
+// })
 
-const iconBgColor = computed(() => {
-    if(cardInfo.value.color == 'red'){
-        return `bg-red-200`
-    }else if(cardInfo.value.color == 'blue'){
-        return `bg-blue-200`
-    }else if(cardInfo.value.color == 'green'){
-        return `bg-green-200`
-    }else if(cardInfo.value.color == 'yellow'){
-        return `bg-yellow-200`
-    }else if(cardInfo.value.color == 'purple'){
-        return `bg-purple-200`
-    }
-})
+// const iconBgColor = computed(() => {
+//     if(cardInfo.value.color == 'red'){
+//         return `bg-red-200`
+//     }else if(cardInfo.value.color == 'blue'){
+//         return `bg-blue-200`
+//     }else if(cardInfo.value.color == 'green'){
+//         return `bg-green-200`
+//     }else if(cardInfo.value.color == 'yellow'){
+//         return `bg-yellow-200`
+//     }else if(cardInfo.value.color == 'purple'){
+//         return `bg-purple-200`
+//     }
+// })
 
-const iconShadowColor = computed(() => {
-    if(cardInfo.value.color == 'red'){
-        return `shadow-red-200/50`
-    }else if(cardInfo.value.color == 'blue'){
-        return `shadow-blue-200/50`
-    }else if(cardInfo.value.color == 'green'){
-        return `shadow-green-200/50`
-    }else if(cardInfo.value.color == 'yellow'){
-        return `shadow-yellow-200/50`
-    }else if(cardInfo.value.color == 'purple'){
-        return `shadow-purple-200/50`
-    }
-})
+// const iconShadowColor = computed(() => {
+//     if(cardInfo.value.color == 'red'){
+//         return `shadow-red-200/50`
+//     }else if(cardInfo.value.color == 'blue'){
+//         return `shadow-blue-200/50`
+//     }else if(cardInfo.value.color == 'green'){
+//         return `shadow-green-200/50`
+//     }else if(cardInfo.value.color == 'yellow'){
+//         return `shadow-yellow-200/50`
+//     }else if(cardInfo.value.color == 'purple'){
+//         return `shadow-purple-200/50`
+//     }
+// })
 
-const textColor = computed(() => {
-    if(cardInfo.value.color == 'red'){
-        return `text-red-100`
-    }else if(cardInfo.value.color == 'blue'){
-        return `text-blue-100`
-    }else if(cardInfo.value.color == 'green'){
-        return `text-green-100`
-    }else if(cardInfo.value.color == 'yellow'){
-        return `text-yellow-100`
-    }else if(cardInfo.value.color == 'purple'){
-        return `text-purple-100`
-    }
-})
+// const textColor = computed(() => {
+//     if(cardInfo.value.color == 'red'){
+//         return `text-red-100`
+//     }else if(cardInfo.value.color == 'blue'){
+//         return `text-blue-100`
+//     }else if(cardInfo.value.color == 'green'){
+//         return `text-green-100`
+//     }else if(cardInfo.value.color == 'yellow'){
+//         return `text-yellow-100`
+//     }else if(cardInfo.value.color == 'purple'){
+//         return `text-purple-100`
+//     }
+// })
 
-const bgColor = computed(() => {
-    if(cardInfo.value.color == 'red'){
-        return `bg-red-700/50`
-    }else if(cardInfo.value.color == 'blue'){
-        return `bg-blue-700/50`
-    }else if(cardInfo.value.color == 'green'){
-        return `bg-green-700/50`
-    }else if(cardInfo.value.color == 'yellow'){
-        return `bg-yellow-700/50`
-    }else if(cardInfo.value.color == 'purple'){
-        return `bg-purple-700/50`
-    }
+// const bgColor = computed(() => {
+//     if(cardInfo.value.color == 'red'){
+//         return `bg-red-700/50`
+//     }else if(cardInfo.value.color == 'blue'){
+//         return `bg-blue-700/50`
+//     }else if(cardInfo.value.color == 'green'){
+//         return `bg-green-700/50`
+//     }else if(cardInfo.value.color == 'yellow'){
+//         return `bg-yellow-700/50`
+//     }else if(cardInfo.value.color == 'purple'){
+//         return `bg-purple-700/50`
+//     }
+// })
+
+// const handle
+onBeforeMount(() => {
+    
 })
 
 onMounted(() => {
@@ -108,14 +117,15 @@ onMounted(() => {
 <template>
     <section class="fixed top-0 left-0 w-screen h-screen z-[100] grid overflow-y-auto overflow-x-hidden md:overflow-hidden backdrop-blur place-content-center">
         <div class="flex items-center gap-4 w-[80vw] 2xl:w-[70vw] h-[80vh]">
-            <button class="p-4 text-white rounded-full arrow bg-black/50 disabled:bg-black/30 disabled:text-white/20 hover:bg-cyan-500">
+            <button class="p-4 text-white rounded-full arrow bg-black/50 disabled:bg-black/30 disabled:text-white/20 hover:bg-cyan-500" @click="changeCardInfoCard('left')" :disabled="leftDisabled" >
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="stroke-2 size-6">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"></path>
                 </svg>
             </button>
             <div class="card flex-none rounded-2xl relative p-0 w-4/12 overflow-hidden shadow-[0_4px_8px_rgba(0,0,0,0.1)]">
                 <div class="absolute top-0 left-0 w-full h-full glossy z-2 mix-blend-lighten"></div>
-                <img class="flex-none object-cover w-full min-w-0 shadow-lg select-none rounded-card aspect-card default-transition bg-image" :src="cardInfo.cover" alt="" size="sm:100vw md:50vw lg:600px">
+                <!-- 動態帶入資料的版本 <img class="flex-none object-cover w-full min-w-0 shadow-lg select-none rounded-card aspect-card default-transition bg-image" :src="cardInfo.cover" alt="" size="sm:100vw md:50vw lg:600px"> -->
+                <img class="flex-none object-cover w-full min-w-0 shadow-lg select-none rounded-card aspect-card default-transition bg-image" src="https://jasonxddd.me:7001/imgproxy/uTz5Qc1RtmVq-UACufPxVQk-G0eFfKvKWXNGEImcyHc/rt:fill/w:0/h:0/g:no/el:1/f:png/bG9jYWw6Ly8vL0hPTF9XMTA0XzEyM1NTUC5wbmc.png" alt="" size="sm:100vw md:50vw lg:600px">
                 <button class="absolute bottom-0 p-4 text-white rounded-full md-arrow left-2 bg-black/50 disabled:bg-black/30 disabled:text-white/20 hover:bg-cyan-500">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="stroke-2 size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"></path>
                     </svg>
@@ -133,7 +143,8 @@ onMounted(() => {
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="stroke-2 size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"></path></svg>
                             </button>
                             <div class="text-white btn btn-sm bg-zinc-700">
-                                <span class="stroke-2 size-6 flex items-center justify-center">{{ cardCount }}</span>
+                                <!-- 動態帶入資料的版本 <span class="stroke-2 size-6 flex items-center justify-center">{{ cardCount }}</span> -->
+                                <span class="text-center stroke-2 size-6">0</span>
                             </div>
                             <button class="text-white btn btn-sm bg-zinc-700 hover:bg-red-400" @click="removeCard(cardInfo)" >
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="stroke-2 size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14"></path></svg>
@@ -154,22 +165,53 @@ onMounted(() => {
                     </div>
                     <div class="flex items-center mt-4 gap-x-2">
                         <div class="flex flex-col items-center justify-center w-16 gap-2">
-                            <div :class="['p-2', iconTextColor, iconBgColor, 'rounded-full', 'shadow-lg', iconShadowColor]">
+                            <div class="p-2 text-blue-700 bg-blue-200 rounded-full shadow-lg shadow-blue-200/50">
+                                <svg  class="size-8" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"></path>
+                                </svg>
+                            </div>
+                            <!-- 動態資料部分 <div :class="['p-2', iconTextColor, iconBgColor, 'rounded-full', 'shadow-lg', iconShadowColor]">
                                 <svg v-if="cardInfo.typeTranslate === '角色' " class="size-8" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"></path>
                                 </svg>
                                 <svg v-else-if="cardInfo.typeTranslate === '名場' " xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-8"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"></path></svg>
                                 <svg v-else-if="cardInfo.typeTranslate === '事件' " xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-8"><path stroke-linecap="round" stroke-linejoin="round" d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z"></path></svg>
-                            </div>
-                            <p class="w-full text-xs text-center text-white truncate">{{ cardInfo.typeTranslate }}</p>
+                            </div> -->
+                            <p class="w-full text-xs text-center text-white truncate">角色</p>
+                            <!-- 動態帶入資料的版本 <p class="w-full text-xs text-center text-white truncate">{{ cardInfo.typeTranslate }}</p> -->
                         </div>
                         <div>
-                            <p class="font-mono text-xs text-zinc-300">{{ cardInfo.id }}</p>
+                            <!-- 動態帶入資料的版本 <p class="font-mono text-xs text-zinc-300">{{ cardInfo.id }}</p>
                             <h3 class="text-2xl font-bold text-white">{{ cardInfo.title }}</h3>
-                            <p class="text-zinc-300">{{ cardInfo.productName }}</p>
+                            <p class="text-zinc-300">{{ cardInfo.productName }}</p> -->
+                            <p class="font-mono text-xs text-zinc-300">HOL/W104-123SSP</p>
+                            <h3 class="text-2xl font-bold text-white">STELLAR into the GALAXY 星街すいせい</h3>
+                            <p class="text-zinc-300">#ホロライブプロダクション Vol.2</p>
                         </div>
                     </div>
                     <div class="flex flex-wrap items-center gap-2 mt-4">
+                        <div class="flex items-center">
+                            <span class="relative px-1 text-blue-100 rounded z-1 whitespace-nowrap bg-blue-700/50">等級</span>
+                            <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">3</span>
+                        </div>
+                        <div class="flex items-center">
+                            <span class="relative px-1 text-blue-100 rounded z-1 whitespace-nowrap bg-blue-700/50">費用</span>
+                            <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">2</span>
+                        </div>
+                        <div class="flex items-center">
+                            <span class="relative px-1 text-blue-100 rounded z-1 whitespace-nowrap bg-blue-700/50">魂傷</span>
+                            <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">2</span>
+                        </div>
+                        <div class="flex items-center">
+                            <span class="relative px-1 text-blue-100 rounded z-1 whitespace-nowrap bg-blue-700/50">攻擊</span>
+                            <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">10000</span>
+                        </div>
+                        <div class="flex items-center">
+                            <span class="relative px-1 text-blue-100 rounded z-1 whitespace-nowrap bg-blue-700/50">稀有度</span>
+                            <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">SSP</span>
+                        </div>
+                    </div>
+                    <!-- 動態帶入資料的版本 <div class="flex flex-wrap items-center gap-2 mt-4">
                         <div class="flex items-center">
                             <span :class="['relative', 'px-1', textColor, 'rounded', 'z-1', 'whitespace-nowrap', bgColor]">等級</span>
                             <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">{{ cardInfo.level }}</span>
@@ -190,7 +232,7 @@ onMounted(() => {
                             <span :class="['relative', 'px-1', textColor, 'rounded', 'z-1', 'whitespace-nowrap', bgColor]">稀有度</span>
                             <span class="bg-black/30 rounded-r pl-2 pr-1 -ml-1 whitespace-nowrap text-white text-center font-mono md:min-w-[2rem]">{{ cardInfo.rare }}</span>
                         </div>
-                    </div>
+                    </div> -->
                     <div class="flex items-center justify-around gap-2 mt-6 overflow-auto">
                         <button class="flex items-center rounded-full group default-transition bg-zinc-700 text-zinc-100 hover:bg-cyan-700 hover:text-cyan-100">
                             <div class="btn btn-sm default-transition bg-zinc-600 group-hover:bg-cyan-600">
@@ -254,7 +296,8 @@ onMounted(() => {
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="m9 7.5 3 4.5m0 0 3-4.5M12 12v5.25M15 12H9m6 3H9m12-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"></path>
                             </svg>
-                            <h3 class="font-mono text-6xl font-bold">{{ cardInfo.price.number }}</h3>
+                            <h3 class="font-mono text-6xl font-bold">448000</h3>
+                            <!-- 動態帶入資料的版本 <h3 class="font-mono text-6xl font-bold">{{ cardInfo.price.number }}</h3> -->
                         </div>
                         <p class="mt-4 text-sm text-zinc-500 dark:text-zinc-300">於 2024-11-07 遊々亭價格更新</p>
                     </div>
@@ -314,7 +357,7 @@ onMounted(() => {
                     </div>
                 </div>
             </div>
-            <button class="p-4 text-white rounded-full arrow bg-black/50 disabled:bg-black/30 disabled:text-white/20 hover:bg-cyan-500">
+            <button class="p-4 text-white rounded-full arrow bg-black/50 disabled:bg-black/30 disabled:text-white/20 hover:bg-cyan-500" @click="changeCardInfoCard('right')" :disabled="rightDisabled" >
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="stroke-2 size-6">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"></path>
                 </svg>

--- a/src/views/CardSeries.vue
+++ b/src/views/CardSeries.vue
@@ -17,8 +17,9 @@ const changeReplaceKeyWord = cardFilterStore.changeReplaceKeyWord
 
 // 引入CardSeriesStore並使用
 const cardSeriesStore = useCardSeriesStore();
-const { seriesCardList } = storeToRefs(cardSeriesStore);
+const { seriesCardList, seriesInfo } = storeToRefs(cardSeriesStore);
 const getLastViewSeries = cardSeriesStore.getLastViewSeries;
+
 
 // 引入DeckMakeStore並使用
 const deckMakeStore = useDeckMakeStore();
@@ -43,6 +44,7 @@ const chooseCoverCard = ref('')
 const deckName = ref('LL牌組')
 const deckDescription = ref('這是測試牌組')
 const settingDeckStatus = ref(false)
+const thisSeriesCardLength = ref(0)
 
 // 清除牌組並回到第一步編輯牌組的狀態
 const clearDeckAndBacktoFirstStep = async() => {
@@ -152,6 +154,7 @@ const handleApplyStatus = () => {
   }
 }
 
+
   const currentSidebar = ref('');
   const sidebarFilterWidth = ref(490);
   const sidebarDeckWidth = ref(490);
@@ -219,13 +222,15 @@ const handleApplyStatus = () => {
       currentMain.value = '';
     }
   }
-  
-  // Lifecycle hooks
-  onMounted(async() => {
-    window.addEventListener('resize', updateScreenSize);
+  onBeforeMount(async()=> {
     await getLastViewSeries();
     getLastDeckEdit();
     switchSortMode();
+    thisSeriesCardLength.value = seriesCardList.value.length
+  })
+  // Lifecycle hooks
+  onMounted(async() => {
+    window.addEventListener('resize', updateScreenSize);
   });
   
   onBeforeUnmount(() => {
@@ -640,7 +645,7 @@ const handleApplyStatus = () => {
           </button>
           <div data-v-3e737e76="" class="w-full min-w-0 text-lg md:text-2xl font-bold text-white">
             <!-- <div data-v-57e635bc="" class="flex items-center gap-4"> -->
-                <h2 class="truncate text-2xl font-bold">リコリス・リコイル</h2>
+                <h2 class="truncate text-2xl font-bold">{{ seriesInfo.name }}</h2>
             <!-- </div> -->
           </div>
           <div class="notice z-10">
@@ -685,19 +690,19 @@ const handleApplyStatus = () => {
           </div>
         </button>
         <section class="info-container">
-          <img src="https://jasonxddd.me:9000/series-cover/rikoriko.jpg">
+          <img :src="seriesInfo.cover">
           <div flex-col class="inner-info-container">
-            <span><i class="fa-regular fa-clone"></i> {{ "這邊等系列卡表好再修改" }}</span>
-            <h1>{{ "這邊等系列卡表好再修改" }}</h1>
+            <span><i class="fa-regular fa-clone"></i> <span v-for="(code, index) in seriesInfo.code" :key="index" >{{ code }}{{ index == seriesInfo.code.length - 1 ? '' : ', '  }}</span></span>
+            <h1>{{ seriesInfo.name }}</h1>
             <div>
               <div>
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentcolor" width="20" height="20" class="icon-scale size-5 md:size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46"></path></svg><span>最新發布{{ " 這邊等系列卡表好再修改" }}</span>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentcolor" width="20" height="20" class="icon-scale size-5 md:size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46"></path></svg><span>最新發布{{ seriesInfo.sellAt[0] }}</span>
               </div>
               <div>
-                <i class="fa-regular fa-clone"></i><span>總數{{ seriesCardList.length }}張</span>
+                <i class="fa-regular fa-clone"></i><span>總數{{ thisSeriesCardLength }}張</span>
               </div>
               <div>
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="16" height="16" aria-hidden="true" data-slot="icon" class="icon-scale size-5 md:size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z"></path></svg><span>篩選出208張</span>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="16" height="16" aria-hidden="true" data-slot="icon" class="icon-scale size-5 md:size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z"></path></svg><span>篩選出{{ seriesCardList.length }}張</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
- card info 左右切換功能
<img width="173" alt="截圖 2024-12-07 上午12 11 26" src="https://github.com/user-attachments/assets/07668fcf-3658-407f-9773-c448033d7e43">

- 重新綁定跳轉至card-series頁面、獲取所選系列卡片的function
<img width="469" alt="截圖 2024-12-07 上午12 12 44" src="https://github.com/user-attachments/assets/bc4baa74-4cc2-4866-bf34-568bab3ca2ab">

- 先註解掉之前在card-info新增的帶入動態資料和計算屬性的部分，避免要修改card-info時會發生錯誤
- 一些小部分的更改