### PR TITLE
Feature/card order

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,10 +11,10 @@ const { cardInfoDisplay } = storeToRefs(cardInfoStore);
 </script>
 
 <template>
-  <div class="overflow-hidden bg-black root-container">
-    <SidebarGrid style="grid-area: sidebar;" />
+  <!-- <div class="overflow-hidden bg-black root-container"> -->
+    <!-- <SidebarGrid style="grid-area: sidebar;" /> -->
     <router-view />
-  </div>
+  <!-- </div> -->
 </template>
 
 <style scoped>

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,10 +11,10 @@ const { cardInfoDisplay } = storeToRefs(cardInfoStore);
 </script>
 
 <template>
-  <!-- <div class="overflow-hidden bg-black root-container"> 
-    <SidebarGrid style="grid-area: sidebar;" />  -->
+  <!-- <div class="overflow-hidden bg-black root-container"> -->
+    <!-- <SidebarGrid style="grid-area: sidebar;" />  -->
     <router-view />
-  <!-- </div>  -->
+  <!-- </div> -->
 </template>
 
 <style scoped>

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,10 +11,10 @@ const { cardInfoDisplay } = storeToRefs(cardInfoStore);
 </script>
 
 <template>
-  <!-- <div class="overflow-hidden bg-black root-container"> -->
-    <!-- <SidebarGrid style="grid-area: sidebar;" /> -->
+  <!-- <div class="overflow-hidden bg-black root-container"> 
+    <SidebarGrid style="grid-area: sidebar;" />  -->
     <router-view />
-  <!-- </div> -->
+  <!-- </div>  -->
 </template>
 
 <style scoped>

--- a/src/components/card-deck/Carddeck.vue
+++ b/src/components/card-deck/Carddeck.vue
@@ -904,7 +904,7 @@ export default {
 
     .message-section{
         width: 95%;
-        height: 80vh;
+        height: 60vh;
     }
 
     .message-scroll{
@@ -1667,16 +1667,16 @@ export default {
         width: 100%;
         display: flex;
         margin-left: 24px;
-        position: absolute;
-        top: 450px;
-        display: none;
+        position: absolute; 
+        top: 450px;  
+        /* display: none; */
     }
 
     .toolbar-area1 {
         width: 50%;
         display: flex;
         gap: 20px;
-        display: none;
+        /* display: none; */
     }
 
     .tool-btn1 {
@@ -1754,7 +1754,7 @@ export default {
         gap: 20px;
         position: absolute;
         right: 50px;
-        display: none;
+        /* display: none; */
     }
 
 
@@ -2167,19 +2167,19 @@ export default {
         .toolbar {
             width: 50%;
             flex-direction: column;
-            display: none;
+            /* display: none; */
         }
         
         .toolbar-area1 {
             width: 50%;
             gap: 8px;
-            display: none;
+            /* display: none; */
         }
         
         .toolbar-area2 {
             width: 50%;
             position: static;
-            display: none;
+            /* display: none; */
         } 
     }
 

--- a/src/components/card-deck/Carddeck.vue
+++ b/src/components/card-deck/Carddeck.vue
@@ -643,6 +643,34 @@ export default {
                             </section>
                         </div>
                     </div>
+                    <div class="card-info">
+                        <div class="row">
+                        <div class="col-Info" v-for="(card, index) in seriesCardList" :key="card.id" @click.stop="addCard(card)" >
+                            <div class="card-info-image">
+                            <img :src="card.cover">
+                            <div class="card-inner-info" @click.stop="getCardInfoAndShow(card)" >
+                                <div class="card-inner-info-header">
+                                <p>{{ card.id }}</p>
+                                <p>{{ card.rare }}</p>
+                                </div>
+                                <h3>{{ card.title }}</h3>
+                                <div class="details">
+                                <div><span :class="`bg-${card.color}`" >類型</span>{{ card.typeTranslate }}</div>
+                                <div><span :class="`bg-${card.color}`" >魂傷</span>{{ card.soul }}</div>
+                                <div><span :class="`bg-${card.color}`" >等級</span>{{ card.level }}</div>
+                                <div><span :class="`bg-${card.color}`" >攻擊</span>{{ card.attack }}</div>
+                                <div><span :class="`bg-${card.color}`" >費用</span>{{ card.cost }}</div>
+                                </div>
+                                <div class="price-download">
+                                <p>${{ card.price.number }}</p>
+                                <button @click.stop="addCard(card)" ><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
+                                </div>
+                            </div>
+                            </div>
+                        </div>
+                        </div>
+                    </div>
+
                     <nav class="toolbar">
                         <div class="toolbar-area1">
                             <button class="tool-btn1">
@@ -694,6 +722,38 @@ export default {
                         </div>
                     </nav>
                 </section>
+                <div v-if="view === 'card-info'" class="card-info">
+                    <div class="row">
+                        <div class="col-Info" v-for="(card, index) in seriesCardList" :key="card.id" @click.stop="addCard(card)" >
+                            <div class="card-info-image">
+                                <img :src="card.cover">
+                                <div class="card-inner-info" @click.stop="getCardInfoAndShow(card)" >
+                                    <div class="card-inner-info-header">
+                                        <p>{{ card.id }}</p>
+                                        <p>{{ card.rare }}</p>
+                                    </div>
+                                    <h3>{{ card.title }}</h3>
+                                    <div class="details">
+                                        <div><span :class="`bg-${card.color}`" >類型</span>{{ card.typeTranslate }}</div>
+                                        <div><span :class="`bg-${card.color}`" >魂傷</span>{{ card.soul }}</div>
+                                        <div><span :class="`bg-${card.color}`" >等級</span>{{ card.level }}</div>
+                                        <div><span :class="`bg-${card.color}`" >攻擊</span>{{ card.attack }}</div>
+                                        <div><span :class="`bg-${card.color}`" >費用</span>{{ card.cost }}</div>
+                                    </div>
+                                    <div class="price-download">
+                                            <p>${{ card.price.number }}</p>
+                                        <button @click.stop="addCard(card)" >
+                                            <svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path>
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <nav class="footer-nav">
                     <a class="nav-link" href="#">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="flex-none w-7 h-7 link-svg"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"></path>
@@ -749,6 +809,220 @@ export default {
 </template>
 
 <style scoped>
+    .row {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0 -5px;
+    box-sizing: border-box;
+    }
+
+    .card-image {
+    display: flex;
+    position: relative;
+    object-fit: cover;
+    border-radius:10px ;
+    overflow: hidden;
+    margin: 5px;
+    box-sizing: border-box;
+    cursor: pointer;
+    }
+
+    .col-Sheet, .col-Info {
+    width:20%;
+    }
+
+    .card-image img {
+    width: 100%;
+    height: auto;
+    display: block;
+    }
+
+    .card-image div {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    position: absolute;
+    bottom: 0;
+    gap:5px;
+    padding: 20px 5px 10px 10px;
+    box-sizing: border-box;
+    color: white;
+    background-image: linear-gradient(transparent, #0009 40%, #000000bf);
+    }
+
+    .card-image div p {
+    margin: 0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
+    }
+
+    .card-image div h3 {
+    margin: 0;
+    font-weight: bold;
+    font-size: 18px;
+    white-space: nowrap; 
+    max-width: calc(100% - 40px); 
+    overflow: hidden;
+    text-overflow: ellipsis;
+    }
+
+    .card-image button {
+    position: absolute;
+    background: transparent;
+    bottom: 10px;
+    right: 5px;
+    width: 40px;
+    height: 40px;
+    border: none;
+    background: none;
+    border-radius: 50%;
+    color: #fff;
+    display: flex;
+    align-items: center; 
+    justify-content: center;
+    cursor: pointer;
+    }
+
+    .card-image:hover div {
+    display: none;
+    }
+
+    .card-image:hover button {
+    border: none;
+    background: rgba(0, 0, 0, 0.697);
+    padding: 5px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center; 
+    justify-content: center;
+    }
+    
+    
+    /* card-info */
+
+    .card-info {
+    padding: 20px;
+    box-sizing: border-box;
+    }
+
+    .card-info-image {
+    display:flex;
+    flex-direction: column;
+    position: relative;
+    border-radius: 10px;
+    overflow: hidden;
+    margin: 5px;
+    background-color: #121212;
+    cursor: pointer;
+    }
+
+    .card-info-image img {
+    width: 100%;
+    height: auto;
+    display: block;
+    }
+
+    .card-inner-info {
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px; 
+    }
+
+    .card-inner-info-header,.price-download {
+    display: flex;
+    justify-content: space-between;
+    color: white;
+    text-align: center;
+    }
+
+    .card-inner-info-header p,.price-download p {
+    color:#71717A;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
+    margin: 0;
+    }
+
+    .card-inner-info-header p:last-child {
+    color: #63DDEE;
+    }
+
+    .card-inner-info h3 {
+    margin:0;
+    color: white;
+    font-weight: bold;
+    white-space: nowrap; 
+    overflow: hidden;
+    text-overflow: ellipsis;
+    }
+
+    .details {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    background-color: #121212;
+    color: white;
+    gap:10px;
+    }
+
+    .details div {
+    width: calc((100% - 10px)/2);
+    }
+
+    .details span{
+    margin-right: 5px;
+    /* background-color: #CA8A04; */
+    border-radius: 7px;
+    padding: 2px;
+    }
+
+    .bg-red {
+    background-color: #ef4444;
+    }
+
+    .bg-blue {
+    background-color: #3b82f6;
+    }
+
+    .bg-green {
+    background-color: #22c55e;
+    }
+
+    .bg-yellow {
+    background-color: #eab308;
+    }
+
+    .bg-purple {
+    background-color: #a855f7;
+    }
+
+    .price-download {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    }
+
+    .price-download p {
+    color: #F59E0B;
+    }
+
+    .price-download button {
+    width: 35px;
+    height:35px;
+    background-color: #ffffff34;
+    border-radius: 50%;
+    border: none;
+    color: white;
+    font-size: 20px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    }
+
+    .price-download button:hover {
+    background-color: #000000;
+    }
+
+
     .send-btn span
     .cancel-btn span{
         font-size: .75rem;

--- a/src/components/card-deck/Carddeck.vue
+++ b/src/components/card-deck/Carddeck.vue
@@ -35,7 +35,7 @@ export default {
         sortBy: "typeTranslate",
         groupedCards: [],
         toggleTableView: false,
-        togglePriceView: false
+        togglePriceView: false,
         };
     },
     mounted() {
@@ -763,7 +763,8 @@ export default {
                             </button>
                         </div>
                         <div class="toolbar-area2">
-                            <button class="func-btn func-btn4" @click="togglePriceTableView">
+                            <button class="func-btn func-btn4" @click="togglePriceTableView"
+                            :style="{ backgroundColor: togglePriceView ? '#060608' : '#06b6d4' }">
                                 <svg data-v-5634e853="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z"></path>
                                 </svg>
                                 <div class="func-text func-text4">開啟價格</div>

--- a/src/components/card-deck/Carddeck.vue
+++ b/src/components/card-deck/Carddeck.vue
@@ -34,6 +34,8 @@ export default {
         sortedCards: [],
         sortBy: "typeTranslate",
         groupedCards: [],
+        toggleTableView: false,
+        togglePriceView: false
         };
     },
     mounted() {
@@ -115,6 +117,12 @@ export default {
         },    
     },
     methods: {
+        togglePriceTableView() {
+            this.togglePriceView = !this.togglePriceView;
+        },
+        toggleViewMode() {
+            this.toggleTableView = !this.toggleTableView;
+        },
         countSoulCards(cards) {
             return cards.filter(card => card.trigger.includes('soul')).length;
         },
@@ -126,11 +134,8 @@ export default {
                 const postCode = this.$route.params.post_code;  // 获取当前路由的 post_code
                 const response = await axios.get(`http://localhost:3000/api/deck/${postCode}`);
 
-                // 遍历所有 deck_list，获取每个 deck 的信息
                 const deckList = response.data[0].deck_list;
-                this.deckName = deckList.deck_name;  // 获取 deck_name
-                this.cards = deckList.deck;  // 获取所有 deck 中的卡片
-                console.log(this.cards);
+                this.cards = deckList.deck;  
 
                 console.log('Deck Name:', this.deckName);
                 console.log('All cards:', this.cards);
@@ -758,15 +763,18 @@ export default {
                             </button>
                         </div>
                         <div class="toolbar-area2">
-                            <button class="func-btn func-btn3">
-                                <svg data-v-5634e853="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z"></path></svg>
-                                <div class="func-text func-text3">開啟價格</div>
+                            <button class="func-btn func-btn4" @click="togglePriceTableView">
+                                <svg data-v-5634e853="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z"></path>
+                                </svg>
+                                <div class="func-text func-text4">開啟價格</div>
                             </button>
-                            <button class="func-btn func-btn5">
+                            <button class="func-btn func-btn5" @click="toggleTableView = true"
+                            :style="{ backgroundColor: toggleTableView ? '#06b6d4' : '' }">
                                 <svg data-v-5634e853="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z"></path></svg>
                                 <div class="func-text func-text5">表格顯示</div>
                             </button>
-                            <button class="func-btn func-btn6">
+                            <button class="func-btn func-btn6" @click="toggleTableView = false"
+                            :style="{ backgroundColor: !toggleTableView ? '#06b6d4' : '' }">
                                 <svg data-v-5634e853="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 3.75V16.5L12 14.25 7.5 16.5V3.75m9 0H18A2.25 2.25 0 0 1 20.25 6v12A2.25 2.25 0 0 1 18 20.25H6A2.25 2.25 0 0 1 3.75 18V6A2.25 2.25 0 0 1 6 3.75h1.5m9 0h-9"></path></svg>
                                 <div class="func-text func-text6">卡片資訊</div>
                             </button>
@@ -784,6 +792,14 @@ export default {
                             </div>
                             <div class="card-row">
                                 <div class="col-Info" v-for="card in group.cards" :key="card.index">
+                                    <p class="price-row" v-if="!togglePriceView">
+                                        <svg data-v-27aeb5c1="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="currency-icon">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="m9 7.5 3 4.5m0 0 3-4.5M12 12v5.25M15 12H9m6 3H9m12-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"></path>
+                                        </svg>
+                                        <span data-v-27aeb5c1="" class="price-row-text">{{ card.price.number }}</span>
+                                        <span data-v-27aeb5c1="" class="price-row-text">{{ card.rare }}</span>
+                                    </p>
+
                                     <div class="card-info-image">
                                         <img :src="card.cover">
                                         <div class="card-inner-info">
@@ -792,14 +808,14 @@ export default {
                                                 <p>{{ card.rare }}</p>
                                             </div>
                                             <h3>{{ card.title }}</h3>
-                                            <div class="details">
+                                            <div class="details" v-if="!toggleTableView">
                                                 <div><span>類型</span>{{ card.typeTranslate }}</div>
                                                 <div><span>魂傷</span>{{ card.soul }}</div>
                                                 <div><span>等級</span>{{ card.level }}</div>
                                                 <div><span>攻擊</span>{{ card.attack }}</div>
                                                 <div><span>費用</span>{{ card.cost }}</div>
                                             </div>
-                                            <div class="price-download">
+                                            <div class="price-download" v-if="!toggleTableView">
                                                 <p> ${{ card.price.number }} </p>
                                             <button><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
                                             </div>
@@ -865,6 +881,23 @@ export default {
 </template>
 
 <style scoped>
+    .price-row{
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-weight: 700;
+        color: #c9a83d;
+        gap: .25rem;
+        margin-top: 30px;
+        font-size: 16px;
+    }
+
+    .currency-icon{
+        width: 20px;
+        height: 20px;
+        stroke: #c9a83d;
+    }
+
     .tool-btn1.active{
         background: linear-gradient(45deg, #7dca31, #21b8c8);
     }
@@ -2072,6 +2105,7 @@ export default {
         color: white;
         font-size: 14px;
         font-weight: 900;
+        width: 100%;
     }
 
     .tool-btn1:hover {
@@ -2120,8 +2154,8 @@ export default {
         visibility: hidden;
         transition:ease 0.3s;
         position:absolute;
-        right:0;
-        top:35px;
+        right: 20px;
+        top: 50px;
     }
 
     .toolbar-area2 {
@@ -2151,11 +2185,11 @@ export default {
     }
 
     .func-text5 {
-        right:-33px;
+        right:-30px;
     }
 
     .func-text6 {
-        right:-35px;
+        right:-25px;
     }
 
     .func-btn1:hover .func-text1,
@@ -2350,6 +2384,19 @@ export default {
     }
 
     @media screen and (max-width: 1199px) {
+        .toolbar {
+            position: absolute;
+            top: 930px;
+        }
+
+        .card-info{
+            margin-top: 400px;
+        }
+
+        .tool-btn1 span{
+            width: 100%;
+        }
+
         .col-Sheet, .col-Info {
             width: calc((100% - 10px) / 3);
         }
@@ -2536,8 +2583,7 @@ export default {
         }
 
         .footer-nav {
-            /* display: flex; */
-            display: none;    
+            display: flex;
         }
 
         .deck-container {
@@ -2551,21 +2597,16 @@ export default {
 
     @media screen and (max-width: 800px) {
         .toolbar {
-            width: 50%;
-            flex-direction: column;
-            /* display: none; */
+            width: 100%;
         }
         
         .toolbar-area1 {
-            width: 50%;
             gap: 8px;
-            /* display: none; */
         }
         
         .toolbar-area2 {
-            width: 50%;
-            position: static;
-            /* display: none; */
+            gap: 8px;
+
         } 
     }
 

--- a/src/components/card-deck/Carddeck.vue
+++ b/src/components/card-deck/Carddeck.vue
@@ -30,7 +30,9 @@ export default {
         loggedInUserId: null,
         token: localStorage.getItem('token'),
         created_at: null,
-        cards:[]
+        cards:[],
+        sortBy: '', 
+        sortedCards: [],
         };
     },
     mounted() {
@@ -38,6 +40,7 @@ export default {
         this.fetchCurrentUser();
         this.fetchDeck();
     },
+
     created() {
         this.loggedInUserId = getUserIdFromToken(this.token);
         console.log("Logged in user ID:", this.loggedInUserId);
@@ -51,9 +54,30 @@ export default {
                 if (!createdAt) return "未知時間";
                 return dayjs(createdAt).format("YYYY-MM-DD HH:mm:ss");
             };
-        },    
-    },
+        },
+        // 根據目前選擇的排序屬性返回排序後的卡片
+        sortedCards() {
+                let sortedCards = [...this.cards];  // 複製卡片資料
+                console.log('Before sorting:', sortedCards); 
+                if (this.sortBy === 'level') {
+                    sortedCards.sort((a, b) => a.level - b.level);  // 依照等級升序排列
+                } else if (this.sortBy === 'type') {
+                    sortedCards.sort((a, b) => a.typeTranslate.localeCompare(b.typeTranslate));  // 依照類型字母順序排列
+                } else if (this.sortBy === 'rare') {
+                    sortedCards.sort((a, b) => a.rare.localeCompare(b.rare, 'en'));  // 依照稀有度字母順序排列
+                }
+                console.log('After sorting:', sortedCards);  // 打印排序後的資料
+                return sortedCards;
+            },    
+        },
     methods: {
+         // 設定排序方式
+        sortCards(property) {
+            if (this.sortBy !== property) {
+                this.sortBy = property;
+                console.log('After sorting:', this.sortedCards);
+            }
+        },        
         async fetchDeck() {
             try {
                 const postCode = this.$route.params.post_code;  // 获取当前路由的 post_code
@@ -63,6 +87,7 @@ export default {
                 const deckList = response.data[0].deck_list;
                 this.deckName = deckList.deck_name;  // 获取 deck_name
                 this.cards = deckList.deck;  // 获取所有 deck 中的卡片
+                console.log(this.cards);
 
                 console.log('Deck Name:', this.deckName);
                 console.log('All cards:', this.cards);
@@ -663,7 +688,7 @@ export default {
                     </div>
                     <nav class="toolbar">
                         <div class="toolbar-area1">
-                            <button class="tool-btn1">
+                            <button class="tool-btn1" @click="sortCards('type')">
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="flex-none size-6 stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M6 10.5h2.25a2.25 2.25 0 0 0 2.25-2.25V6a2.25 2.25 0 0 0-2.25-2.25H6A2.25 2.25 0 0 0 3.75 6v2.25A2.25 2.25 0 0 0 6 10.5Zm0 9.75h2.25A2.25 2.25 0 0 0 10.5 18v-2.25a2.25 2.25 0 0 0-2.25-2.25H6a2.25 2.25 0 0 0-2.25 2.25V18A2.25 2.25 0 0 0 6 20.25Zm9.75-9.75H18a2.25 2.25 0 0 0 2.25-2.25V6A2.25 2.25 0 0 0 18 3.75h-2.25A2.25 2.25 0 0 0 13.5 6v2.25a2.25 2.25 0 0 0 2.25 2.25Z"></path></svg>
                                 <span>類型</span>
                             </button>
@@ -671,11 +696,11 @@ export default {
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="flex-none size-6 stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M6 10.5h2.25a2.25 2.25 0 0 0 2.25-2.25V6a2.25 2.25 0 0 0-2.25-2.25H6A2.25 2.25 0 0 0 3.75 6v2.25A2.25 2.25 0 0 0 6 10.5Zm0 9.75h2.25A2.25 2.25 0 0 0 10.5 18v-2.25a2.25 2.25 0 0 0-2.25-2.25H6a2.25 2.25 0 0 0-2.25 2.25V18A2.25 2.25 0 0 0 6 20.25Zm9.75-9.75H18a2.25 2.25 0 0 0 2.25-2.25V6A2.25 2.25 0 0 0 18 3.75h-2.25A2.25 2.25 0 0 0 13.5 6v2.25a2.25 2.25 0 0 0 2.25 2.25Z"></path></svg>
                                 <span>顏色</span>
                             </button>
-                            <button class="tool-btn1">
+                            <button class="tool-btn1" @click="sortCards('level')">
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="flex-none size-6 stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M6 10.5h2.25a2.25 2.25 0 0 0 2.25-2.25V6a2.25 2.25 0 0 0-2.25-2.25H6A2.25 2.25 0 0 0 3.75 6v2.25A2.25 2.25 0 0 0 6 10.5Zm0 9.75h2.25A2.25 2.25 0 0 0 10.5 18v-2.25a2.25 2.25 0 0 0-2.25-2.25H6a2.25 2.25 0 0 0-2.25 2.25V18A2.25 2.25 0 0 0 6 20.25Zm9.75-9.75H18a2.25 2.25 0 0 0 2.25-2.25V6A2.25 2.25 0 0 0 18 3.75h-2.25A2.25 2.25 0 0 0 13.5 6v2.25a2.25 2.25 0 0 0 2.25 2.25Z"></path></svg>
                                 <span>等級</span>
                             </button>
-                            <button class="tool-btn1" style="min-width: 86px">
+                            <button class="tool-btn1" style="min-width: 86px" @click="sortCards('rare')">
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="flex-none size-6 stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M6 10.5h2.25a2.25 2.25 0 0 0 2.25-2.25V6a2.25 2.25 0 0 0-2.25-2.25H6A2.25 2.25 0 0 0 3.75 6v2.25A2.25 2.25 0 0 0 6 10.5Zm0 9.75h2.25A2.25 2.25 0 0 0 10.5 18v-2.25a2.25 2.25 0 0 0-2.25-2.25H6a2.25 2.25 0 0 0-2.25 2.25V18A2.25 2.25 0 0 0 6 20.25Zm9.75-9.75H18a2.25 2.25 0 0 0 2.25-2.25V6A2.25 2.25 0 0 0 18 3.75h-2.25A2.25 2.25 0 0 0 13.5 6v2.25a2.25 2.25 0 0 0 2.25 2.25Z"></path></svg>
                                 <span>稀有度</span>
                             </button>
@@ -713,9 +738,9 @@ export default {
                     </nav>
                     <div class="card-info">
                         <div class="row">
-                            <div class="col-Info" v-for="card in cards" :key="card.id">
+                            <div class="col-Info" v-for="card in sortedCards" :key="card.id">
                                 <div class="card-info-image">
-                                    <img src="https://jasonxddd.me:7001/imgproxy/4nZhC0JVu4aRvo6ml6VI37hURt9V19vRRN5Wo54yrqU/g:no/el:1/bG9jYWw6Ly8vL0xSQ19XMTA1XzAwMS5wbmc.png">
+                                    <img :src="card.cover">
                                     <div class="card-inner-info">
                                         <div class="card-inner-info-header">
                                             <p>{{ card.id }}</p>

--- a/src/components/card-deck/Carddeck.vue
+++ b/src/components/card-deck/Carddeck.vue
@@ -30,11 +30,13 @@ export default {
         loggedInUserId: null,
         token: localStorage.getItem('token'),
         created_at: null,
+        cards:[]
         };
     },
     mounted() {
         this.fetchArticleId();
         this.fetchCurrentUser();
+        this.fetchDeck();
     },
     created() {
         this.loggedInUserId = getUserIdFromToken(this.token);
@@ -52,6 +54,22 @@ export default {
         },    
     },
     methods: {
+        async fetchDeck() {
+            try {
+                const postCode = this.$route.params.post_code;  // 获取当前路由的 post_code
+                const response = await axios.get(`http://localhost:3000/api/deck/${postCode}`);
+
+                // 遍历所有 deck_list，获取每个 deck 的信息
+                const deckList = response.data[0].deck_list;
+                this.deckName = deckList.deck_name;  // 获取 deck_name
+                this.cards = deckList.deck;  // 获取所有 deck 中的卡片
+
+                console.log('Deck Name:', this.deckName);
+                console.log('All cards:', this.cards);
+            } catch (error) {
+                console.error('Failed to fetch specific deck:', error);
+            }
+        },
         async fetchCurrentUser() {
             try {
                 const userToken = localStorage.getItem("token");
@@ -643,34 +661,6 @@ export default {
                             </section>
                         </div>
                     </div>
-                    <div class="card-info">
-                        <div class="row">
-                        <div class="col-Info" v-for="(card, index) in seriesCardList" :key="card.id" @click.stop="addCard(card)" >
-                            <div class="card-info-image">
-                            <img :src="card.cover">
-                            <div class="card-inner-info" @click.stop="getCardInfoAndShow(card)" >
-                                <div class="card-inner-info-header">
-                                <p>{{ card.id }}</p>
-                                <p>{{ card.rare }}</p>
-                                </div>
-                                <h3>{{ card.title }}</h3>
-                                <div class="details">
-                                <div><span :class="`bg-${card.color}`" >類型</span>{{ card.typeTranslate }}</div>
-                                <div><span :class="`bg-${card.color}`" >魂傷</span>{{ card.soul }}</div>
-                                <div><span :class="`bg-${card.color}`" >等級</span>{{ card.level }}</div>
-                                <div><span :class="`bg-${card.color}`" >攻擊</span>{{ card.attack }}</div>
-                                <div><span :class="`bg-${card.color}`" >費用</span>{{ card.cost }}</div>
-                                </div>
-                                <div class="price-download">
-                                <p>${{ card.price.number }}</p>
-                                <button @click.stop="addCard(card)" ><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
-                                </div>
-                            </div>
-                            </div>
-                        </div>
-                        </div>
-                    </div>
-
                     <nav class="toolbar">
                         <div class="toolbar-area1">
                             <button class="tool-btn1">
@@ -721,39 +711,34 @@ export default {
                             </button>
                         </div>
                     </nav>
-                </section>
-                <div v-if="view === 'card-info'" class="card-info">
-                    <div class="row">
-                        <div class="col-Info" v-for="(card, index) in seriesCardList" :key="card.id" @click.stop="addCard(card)" >
-                            <div class="card-info-image">
-                                <img :src="card.cover">
-                                <div class="card-inner-info" @click.stop="getCardInfoAndShow(card)" >
-                                    <div class="card-inner-info-header">
-                                        <p>{{ card.id }}</p>
-                                        <p>{{ card.rare }}</p>
-                                    </div>
-                                    <h3>{{ card.title }}</h3>
-                                    <div class="details">
-                                        <div><span :class="`bg-${card.color}`" >類型</span>{{ card.typeTranslate }}</div>
-                                        <div><span :class="`bg-${card.color}`" >魂傷</span>{{ card.soul }}</div>
-                                        <div><span :class="`bg-${card.color}`" >等級</span>{{ card.level }}</div>
-                                        <div><span :class="`bg-${card.color}`" >攻擊</span>{{ card.attack }}</div>
-                                        <div><span :class="`bg-${card.color}`" >費用</span>{{ card.cost }}</div>
-                                    </div>
-                                    <div class="price-download">
-                                            <p>${{ card.price.number }}</p>
-                                        <button @click.stop="addCard(card)" >
-                                            <svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path>
-                                            </svg>
-                                        </button>
+                    <div class="card-info">
+                        <div class="row">
+                            <div class="col-Info" v-for="card in cards" :key="card.id">
+                                <div class="card-info-image">
+                                    <img src="https://jasonxddd.me:7001/imgproxy/4nZhC0JVu4aRvo6ml6VI37hURt9V19vRRN5Wo54yrqU/g:no/el:1/bG9jYWw6Ly8vL0xSQ19XMTA1XzAwMS5wbmc.png">
+                                    <div class="card-inner-info">
+                                        <div class="card-inner-info-header">
+                                            <p>{{ card.id }}</p>
+                                            <p>{{ card.rare }}</p>
+                                        </div>
+                                        <h3>{{ card.title }}</h3>
+                                        <div class="details">
+                                            <div><span>類型</span>{{ card.typeTranslate }}</div>
+                                            <div><span>魂傷</span>{{ card.soul }}</div>
+                                            <div><span>等級</span>{{ card.level }}</div>
+                                            <div><span>攻擊</span>{{ card.attack }}</div>
+                                            <div><span>費用</span>{{ card.cost }}</div>
+                                        </div>
+                                        <div class="price-download">
+                                            <p> ${{ card.price.number }} </p>
+                                        <button><svg data-v-69cfbdbc="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-7 text-white stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3"></path></svg></button>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                </div>
-
+                </section>
                 <nav class="footer-nav">
                     <a class="nav-link" href="#">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="flex-none w-7 h-7 link-svg"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"></path>
@@ -817,7 +802,7 @@ export default {
     }
 
     .card-image {
-    display: flex;
+    /* display: flex; */
     position: relative;
     object-fit: cover;
     border-radius:10px ;
@@ -828,7 +813,7 @@ export default {
     }
 
     .col-Sheet, .col-Info {
-    width:20%;
+    width: calc((100% - 10px)/4);
     }
 
     .card-image img {
@@ -902,6 +887,8 @@ export default {
     .card-info {
     padding: 20px;
     box-sizing: border-box;
+    position: absolute;
+    top: 580px;
     }
 
     .card-info-image {
@@ -1673,10 +1660,11 @@ export default {
     main {
         margin-top: 8px;
         position: relative;
-        width: calc(100% - 8px);
+        /* width: calc(100% - 8px); 
         /* height: calc(100vh - 1rem); */
         height: auto;
         overflow: hidden;
+        overflow-y: scroll;
         scroll-behavior: smooth;
         border-radius: 20px 20px 0 0;
     }
@@ -1942,7 +1930,7 @@ export default {
         display: flex;
         margin-left: 24px;
         position: absolute; 
-        top: 450px;  
+        top: 550px;  
         /* display: none; */
     }
 
@@ -2241,7 +2229,18 @@ export default {
         margin-left: 5px;
     }
 
+    @media screen and (min-width: 1400px) {
+        .col-Sheet, .col-Info {
+            width: calc((100% - 10px) / 5);
+        }
+
+    }
+
     @media screen and (max-width: 1199px) {
+        .col-Sheet, .col-Info {
+            width: calc((100% - 10px) / 3);
+        }
+
         textarea {
             color: white !important;
             text-align: left !important;
@@ -2455,6 +2454,13 @@ export default {
             position: static;
             /* display: none; */
         } 
+    }
+
+    @media screen and (max-width: 768px) {
+        .col-Sheet, .col-Info {
+            width: calc((100% - 10px) / 2);
+        }
+
     }
 
     @media screen and (max-width: 410px) {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -143,7 +143,7 @@ const router = createRouter({
       component: RemitCardNf,
       path: "/deck",
       name: "deck",
-      component: MyCardView
+      component: MyCard,
     },
     {
       path: '/auth-success',

--- a/src/views/CardSeries.vue
+++ b/src/views/CardSeries.vue
@@ -230,13 +230,13 @@ const handleApplyStatus = () => {
     }
   }
   onBeforeMount(async()=> {
+  })
+  // Lifecycle hooks
+  onMounted(async() => {
     await getLastViewSeries();
     getLastDeckEdit();
     switchSortMode();
     thisSeriesCardLength.value = seriesCardList.value.length
-  })
-  // Lifecycle hooks
-  onMounted(async() => {
     window.addEventListener('resize', updateScreenSize);
   });
   


### PR DESCRIPTION
卡片分組及排序
- 類型
<img width="789" alt="截圖 2024-12-15 下午4 21 08" src="https://github.com/user-attachments/assets/c27c94e0-5c37-4fc7-bf75-1d2d1b8f4a92"/>

- 顏色
<img width="789" alt="截圖 2024-12-15 下午4 21 20" src="https://github.com/user-attachments/assets/41e6ead6-364e-436e-9b7e-d0ba0ba0bbcd" />

- 等級
<img width="789" alt="截圖 2024-12-15 下午4 21 45" src="https://github.com/user-attachments/assets/810e69c3-d5c6-49b0-993e-3ee82422a59c" />

- 稀有度
<img width="789" alt="截圖 2024-12-15 下午4 22 00" src="https://github.com/user-attachments/assets/8c1ffe35-19b6-4799-8063-1547b914e075" />

- 商品 (正常應使用productname 但做不出來所以改用較簡單的seriescode分組及排序)
<img width="789" alt="截圖 2024-12-15 下午4 22 18" src="https://github.com/user-attachments/assets/d3bafbd9-3704-45f5-8516-759906a9cb15" />

- 開啟價格
<img width="789" alt="截圖 2024-12-15 下午4 22 35" src="https://github.com/user-attachments/assets/fe32f46d-354a-452f-a2a9-07c2b6a202af" />

- 表格顯示
<img width="789" alt="截圖 2024-12-15 下午4 22 48" src="https://github.com/user-attachments/assets/dbd5c12d-4a85-4d5a-a0ef-46ba392802d3" />

- 卡片資訊
<img width="789" alt="截圖 2024-12-15 下午4 23 00" src="https://github.com/user-attachments/assets/c7fe69cf-c996-4e03-b2e6-719b5834d3be" />

- 樣式還未修改
關掉app.vue sidebar，背景為變灰且<=768px時會出現黑塊
原頁面最上方的bar與原版面跑版
<img width="804" alt="截圖 2024-12-15 下午4 23 28" src="https://github.com/user-attachments/assets/dfdb0ed0-a6ac-4bbc-87e9-8043d8cfbb8c" />
