### PR TITLE
fix deck-make feature

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,10 +11,10 @@ const { cardInfoDisplay } = storeToRefs(cardInfoStore);
 </script>
 
 <template>
-<div class="overflow-hidden bg-black root-container"> 
-    <SidebarGrid style="grid-area: sidebar;" /> 
+<!-- <div class="overflow-hidden bg-black root-container">  -->
+    <!-- <SidebarGrid style="grid-area: sidebar;" />  -->
     <router-view />
- </div>
+ <!-- </div> -->
 </template>
 
 <style scoped>

--- a/src/assets/css/login-homepage/Login Homepage.css
+++ b/src/assets/css/login-homepage/Login Homepage.css
@@ -324,6 +324,8 @@ nav {
   overflow-y: auto;
   /* width: 85%; */
   overflow-x: hidden;
+  position: relative;
+  left: 270px;
   /* fix */
   border-radius: 1rem;
   background-color: #121212;

--- a/src/components/LoginHomepage.vue
+++ b/src/components/LoginHomepage.vue
@@ -1,6 +1,6 @@
 <script setup>
-import Sidebar from '@/components/work-shop/SideBar.vue'
 import { onMounted } from 'vue'
+import SidebarGrid from '@/components/SidebarGrid.vue'
 
 onMounted(() => {
   import ("@/assets/js/login-homepage/css-control.js")
@@ -14,6 +14,7 @@ onMounted(() => {
 
 <template>
     <div class="All">
+      <SidebarGrid />
       <div class="container">
         <!-- 通知與登入 -->
         <div class="icons">

--- a/src/components/card-deck/deck-page.vue
+++ b/src/components/card-deck/deck-page.vue
@@ -1,6 +1,7 @@
 <script>
 import axios from 'axios';
 import Swal from 'sweetalert2';
+import { useDeckMakeStore } from "@/stores/deck-make";
 
 function getUserIdFromToken(token) {
     try {
@@ -23,6 +24,7 @@ export default {
             sortBy: '', // 用於設置排序條件
             togglePriceView: false, // 用於切換價格表顯示
             toggleTableView: false, // 用於切換顯示模式
+            deckMakeStore: useDeckMakeStore(),
         };
     },
     computed: {
@@ -160,6 +162,27 @@ export default {
         setSortBy(property) {
             this.sortBy = property; // 設定排序條件
         },
+        async copyDeck(){
+            this.deckMakeStore.selectedCards = this.deckData.deck
+            const cardCode = this.deckData.deck[0].seriesCode
+            console.log(cardCode);
+            
+            let seriesId = ''
+            try {
+                const response = await axios.get(`http://localhost:3000/api/series`)
+                seriesId = response.data.find((series)=> {
+                    if(series.code.includes(cardCode)){
+                        return series
+                    }
+                }).id
+                
+            } catch (error) {
+                
+            }
+            console.log(seriesId);
+            
+            this.$router.push(`/card-series/${ seriesId }`)
+        }
     }
 };
 </script>
@@ -230,7 +253,7 @@ export default {
                                 <svg data-v-262b8d44="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-6 stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"></path></svg>
                                 <div class="description-item description1">分享</div>
                             </button>
-                            <button class="social-btn-item social-btn2">
+                            <button class="social-btn-item social-btn2" @click="copyDeck" >
                                 <svg data-v-262b8d44="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="size-6 stroke-2"><path stroke-linecap="round" stroke-linejoin="round" d="M11.35 3.836c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m8.9-4.414c.376.023.75.05 1.124.08 1.131.094 1.976 1.057 1.976 2.192V16.5A2.25 2.25 0 0 1 18 18.75h-2.25m-7.5-10.5H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V18.75m-7.5-10.5h6.375c.621 0 1.125.504 1.125 1.125v9.375m-8.25-3 1.5 1.5 3-3.75"></path></svg>
                                 <div class="description-item description2">複製牌組</div>
                             </button>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -104,8 +104,7 @@ const router = createRouter({
     //   component: LoginHomePageView,
     // },
     {
-      path: "/card-series",
-      name: "card-series",
+      path: "/card-series/:series_id",
       component: CardSeries
     },
     {

--- a/src/stores/card-series.js
+++ b/src/stores/card-series.js
@@ -1,6 +1,7 @@
 import { ref, computed, reactive } from "vue";
 import { defineStore } from "pinia";
 import axios from "axios";
+import { useRoute } from 'vue-router';
 
 export const useCardSeriesStore = defineStore("card-series", () => {
   
@@ -78,13 +79,17 @@ export const useCardSeriesStore = defineStore("card-series", () => {
 
   // 獲取最後瀏覽的系列
   const getLastViewSeries = async () => {
+    const route = useRoute();
+    const seriesId = route.params.series_id;
     // console.log(seriesCardList.value);
-    if (seriesCardList.value.length === 0) {
-      const lastViewSeriesId = localStorage.getItem("lastViewSeriesId");
-      if (lastViewSeriesId) {
-        // console.log("開始重新獲取");
-        await getSeriesCards(lastViewSeriesId);
-      }
+    // if (seriesCardList.value.length === 0) {
+    //   const lastViewSeriesId = localStorage.getItem("lastViewSeriesId");
+    //   if(lastViewSeriesId){
+    //     await getSeriesCards(lastViewSeriesId);
+    //   }
+    // }
+    if (seriesId) {
+      await getSeriesCards(seriesId);
     }
   };
 

--- a/src/stores/card-series.js
+++ b/src/stores/card-series.js
@@ -42,7 +42,7 @@ export const useCardSeriesStore = defineStore("card-series", () => {
   // 獲取指定系列所有卡牌資訊;
   const getSeriesCards = async (seriesId) => {
     try {
-      const seriesRes = await axios.get(`http://localhost:3000/api/serise`);
+      const seriesRes = await axios.get(`http://localhost:3000/api/series`);
       const selectedSeries = seriesRes.data.find((series) => {
         return series.id == seriesId;
       })
@@ -50,7 +50,7 @@ export const useCardSeriesStore = defineStore("card-series", () => {
       seriesInfo.value = selectedSeries;
       // console.log(seriesInfo.value);
       
-      const res = await axios.get(`http://localhost:3000/api/serise/${seriesId}`);
+      const res = await axios.get(`http://localhost:3000/api/series/${seriesId}`);
         // console.log(res.data);
       res.data.forEach((card) => {
         if (card.type === "キャラ") {

--- a/src/views/Card List by Series.vue
+++ b/src/views/Card List by Series.vue
@@ -320,7 +320,7 @@ const handleSeries = async(seriesId) => {
         // 先獲取系列卡片數據
         await getSeriesCards(seriesId);
         
-        router.push('/card-series');
+        router.push(`/card-series/${ seriesId }`);
 
         // 保存最後瀏覽的系列
         saveLastViewSeries(seriesId);    

--- a/src/views/CardSeries.vue
+++ b/src/views/CardSeries.vue
@@ -146,10 +146,10 @@ const finalStep = async() => {
                 title: '成功',
                 text: '成功創建牌組'
               })
-      router.push('/carddeck')
+      router.push(`/deckPage/${ res.data.data.deck_id }`)
       console.log("完成創建牌組並跳轉");
     }else if(res.status == 403){
-      awaitSwal.fire({
+      await Swal.fire({
                 icon: 'error',
                 title: '錯誤',
                 text: '請重新登入'

--- a/src/views/HeroMemberView.vue
+++ b/src/views/HeroMemberView.vue
@@ -1,8 +1,8 @@
 <script setup>
 import MainFooter from "@/components/MainFooter.vue";
 import PageControl from "@/components/work-shop/PageControl.vue";
-import SideBar from "@/components/work-shop/SideBar.vue";
 import { onMounted, ref } from "vue";
+import SidebarGrid from "@/components/SidebarGrid.vue";
 
 onMounted(() => {
     import("@/assets/js/hero-member/hero-member-animation.js")
@@ -12,7 +12,7 @@ onMounted(() => {
 
 <template>
     <div class="hero-member-page-container">
-        <SideBar />
+        <SidebarGrid />
         <div class="hero-member-main-content-container">
           <header class="hero-member-header">
             <PageControl />

--- a/src/views/WorkShopView.vue
+++ b/src/views/WorkShopView.vue
@@ -1,9 +1,9 @@
 <script setup>
 // import PageControl from '@/components/PageControl.vue'
 import MainFooter from '@/components/MainFooter.vue'
-import Sidebar from '@/components/work-shop/SideBar.vue'
 import PageControl from '@/components/work-shop/PageControl.vue';
 import router from '@/router'
+import SidebarGrid from "@/components/SidebarGrid.vue";
 
 const workShopData = [
   {
@@ -39,7 +39,7 @@ const workShopData = [
 
 <template>
   <div class="work-shop-page-container">
-    <Sidebar />
+    <SidebarGrid />
     <div class="work-shop-main-content-container">
       <header class="work-shop-header">
         <PageControl />

--- a/src/views/WorkShopView.vue
+++ b/src/views/WorkShopView.vue
@@ -58,7 +58,7 @@ const workShopData = [
               <i class="fa-solid fa-arrow-right"></i>
             </div>
           </a>
-          <router-link to="/" class="hero-member-box">
+          <router-link to="/hero-member" class="hero-member-box">
             <div class="hero-member-box-left-icon">
               <i class="fa-solid fa-star"></i>
             </div>


### PR DESCRIPTION
- 修改製作完成牌組後router.push的path
- 順便把工作坊、英雄榜原來的SideBar一起替換SidebarGrid
- 登入後首頁引入SidebarGrid
- 新增複製牌組功能
**card-series store獲取卡片的方法，改為使用網址id**
<img width="472" alt="截圖 2024-12-19 下午1 30 24" src="https://github.com/user-attachments/assets/2d51e163-dc4a-4e46-a913-0fcd6f83d92e" />
<img width="337" alt="截圖 2024-12-19 下午1 30 52" src="https://github.com/user-attachments/assets/5ff13b5e-5899-4bb9-9a51-21c99498f806" />


<img width="1280" alt="截圖 2024-12-19 上午10 50 07" src="https://github.com/user-attachments/assets/36f2a869-2c64-4034-b9cf-9ae881a8bef9" />
<img width="1280" alt="截圖 2024-12-19 上午10 56 20" src="https://github.com/user-attachments/assets/cbe2c282-6695-44f9-a814-d24b92da9fe3" />
<img width="1280" alt="截圖 2024-12-19 上午11 28 01" src="https://github.com/user-attachments/assets/271a0afc-ad1c-4310-913f-48a26478a7c2" />


